### PR TITLE
Use a single process by default

### DIFF
--- a/models/cs/run_bart_val.py
+++ b/models/cs/run_bart_val.py
@@ -111,9 +111,9 @@ def main():
             outputs = pool.map(run_model, range(len(data)))
     else:
         outputs = map(run_model, range(len(data)))
+    save_outputs(outputs, args.output_path)
     time_taken = time.perf_counter() - start_time
     logging.info(f'Run Time = {time_taken:}s')
-    save_outputs(outputs, args.output_path)
 
 
 def save_outputs(outputs, output_path):

--- a/models/cs/run_bart_val.py
+++ b/models/cs/run_bart_val.py
@@ -104,12 +104,16 @@ def run_model(i):
 
 
 def main():
-    with multiprocessing.Pool(20) as pool:
-        start_time = time.perf_counter()
-        outputs = pool.map(run_model, range(len(data)))
-        time_taken = time.perf_counter() - start_time
-        logging.info(f'Run Time = {time_taken:}s')
-        save_outputs(outputs, args.output_path)
+    start_time = time.perf_counter()
+    num_processes = multiprocessing.cpu_count() // 4
+    if args.multiprocessing and num_processes > 1:
+        with multiprocessing.Pool(num_processes) as pool:
+            outputs = pool.map(run_model, range(len(data)))
+    else:
+        outputs = map(run_model, range(len(data)))
+    time_taken = time.perf_counter() - start_time
+    logging.info(f'Run Time = {time_taken:}s')
+    save_outputs(outputs, args.output_path)
 
 
 def save_outputs(outputs, output_path):
@@ -131,6 +135,8 @@ if __name__ == '__main__':
                         help='Number of iterations to run the reconstruction algorithm')
     parser.add_argument('--reg-wt', type=float, default=0.01,
                         help='Regularization weight parameter')
+    parser.add_argument('--multiprocessing', action='store_true',
+                        help='Enable multiprocessing')
     args = parser.parse_args()
 
     random.seed(args.seed)


### PR DESCRIPTION
Some users are having issues with Python's multiprocessing (Issue https://github.com/facebookresearch/fastMRI/issues/2). I suggest we leave multiprocessing off by default, but keep it as an option (--multiprocessing).

Also, I changed the default number of processes to num_cpus // 4.

If you approve of this PR, I need to make the same changes to run_bart_train.py before we merge.