### PR TITLE
Fixed negative zero bug in mask

### DIFF
--- a/data/test_transforms.py
+++ b/data/test_transforms.py
@@ -32,7 +32,7 @@ def test_apply_mask(shape, center_fractions, accelerations):
     assert output.shape == input.shape
     assert mask.shape == expected_mask.shape
     assert np.all(expected_mask.numpy() == mask.numpy())
-    assert np.all((output * mask).numpy() == output.numpy())
+    assert np.all(np.where(mask.numpy() == 0, 0, output.numpy()) == output.numpy())
 
 
 @pytest.mark.parametrize('shape', [

--- a/data/transforms.py
+++ b/data/transforms.py
@@ -45,7 +45,7 @@ def apply_mask(data, mask_func, seed=None):
     shape = np.array(data.shape)
     shape[:-3] = 1
     mask = mask_func(shape, seed)
-    return data * mask, mask
+    return torch.where(mask == 0, torch.Tensor([0]), data), mask
 
 
 def fft2(data):


### PR DESCRIPTION
Fixed a subtle bug in the masking code. 
The old code applies the sub-sampling mask to k-space by multiplying k-space data with the mask. The resulting masked k-space can have 0 or -0 in the unobserved k-space points, which leaks information about the sign of the unobserved k-space  points.
With this change, the unobserved k-space points always take on the value of 0 after applying the mask.