### PR TITLE
Brain Dataset Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ possible in applications where it is currently prohibitively slow or expensive.
 
 [fastMRI](http://fastMRI.org) is a collaborative research project from Facebook AI Research (FAIR)
 and NYU Langone Health to investigate the use of AI to make MRI scans faster.
-NYU Langone Health has released fully anonymized Knee MRI datasets that can
+NYU Langone Health has released fully anonymized knee and brain MRI datasets that can
 be downloaded from [the fastMRI dataset page](https://fastmri.med.nyu.edu/).
 
 

--- a/common/args.py
+++ b/common/args.py
@@ -34,6 +34,8 @@ class Args(argparse.ArgumentParser):
                           help='Fraction of total volumes to include')
 
         # Mask parameters
+        self.add_argument('--mask-type', choices=['random', 'equispaced'], default='random',
+                          help='The type of mask function to use')
         self.add_argument('--accelerations', nargs='+', default=[4, 8], type=int,
                           help='Ratio of k-space columns to be sampled. If multiple values are '
                                'provided, then one of those is chosen uniformly at random for '

--- a/common/evaluate.py
+++ b/common/evaluate.py
@@ -100,7 +100,8 @@ if __name__ == '__main__':
                         help='Path to reconstructions')
     parser.add_argument('--challenge', choices=['singlecoil', 'multicoil'], required=True,
                         help='Which challenge')
-    parser.add_argument('--acquisition', choices=['CORPD_FBK', 'CORPDFS_FBK'], default=None,
+    parser.add_argument('--acquisition', choices=['CORPD_FBK', 'CORPDFS_FBK', 'AXT1', 'AXT1PRE',
+                        'AXT1POST', 'AXT2', 'AXFLAIR'], default=None,
                         help='If set, only volumes of the specified acquisition type are used '
                              'for evaluation. By default, all volumes are included.')
     args = parser.parse_args()

--- a/common/subsample.py
+++ b/common/subsample.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 
 
-def mask_for_mask_type(mask_type_str, center_fractions, accelerations):
+def create_mask_for_mask_type(mask_type_str, center_fractions, accelerations):
     if mask_type_str == 'random':
         return RandomMaskFunc(center_fractions, accelerations)
     elif mask_type_str == 'equispaced':
@@ -18,7 +18,33 @@ def mask_for_mask_type(mask_type_str, center_fractions, accelerations):
         raise Exception(f"{mask_type_str} not supported")
 
 
-class RandomMaskFunc():
+class MaskFunc():
+    def __init__(self, center_fractions, accelerations):
+        """
+        Args:
+            center_fractions (List[float]): Fraction of low-frequency columns to be retained.
+                If multiple values are provided, then one of these numbers is chosen uniformly
+                each time.
+
+            accelerations (List[int]): Amount of under-sampling. This should have the same length
+                as center_fractions. If multiple values are provided, then one of these is chosen
+                uniformly each time.
+        """
+        if len(center_fractions) != len(accelerations):
+            raise ValueError('Number of center fractions should match number of accelerations')
+
+        self.center_fractions = center_fractions
+        self.accelerations = accelerations
+        self.rng = np.random.RandomState()
+
+    def choose_acceleration(self):
+        choice = self.rng.randint(0, len(self.accelerations))
+        center_fraction = self.center_fractions[choice]
+        acceleration = self.accelerations[choice]
+        return center_fraction, acceleration
+
+
+class RandomMaskFunc(MaskFunc):
     """
     RandomMaskFunc creates a sub-sampling mask of a given shape.
 
@@ -73,10 +99,7 @@ class RandomMaskFunc():
 
         self.rng.seed(seed)
         num_cols = shape[-2]
-
-        choice = self.rng.randint(0, len(self.accelerations))
-        center_fraction = self.center_fractions[choice]
-        acceleration = self.accelerations[choice]
+        center_fraction, acceleration = self.choose_acceleration()
 
         # Create the mask
         num_low_freqs = int(round(num_cols * center_fraction))
@@ -92,7 +115,7 @@ class RandomMaskFunc():
 
         return mask
 
-class EquispacedMaskFunc():
+class EquispacedMaskFunc(MaskFunc):
     """
     EquispacedMaskFunc creates a sub-sampling mask of a given shape.
 
@@ -108,26 +131,6 @@ class EquispacedMaskFunc():
     (center_fraction, acceleration) is chosen uniformly at random each time the EquispacedMaskFunc
     object is called.
     """
-
-    def __init__(self, center_fractions, accelerations):
-        """
-        Args:
-            center_fractions (List[float]): Fraction of low-frequency columns to be retained.
-                If multiple values are provided, then one of these numbers is chosen uniformly
-                each time.
-
-            accelerations (List[int]): Amount of under-sampling. This should have the same length
-                as center_fractions. If multiple values are provided, then one of these is chosen
-                uniformly each time. An acceleration of 4 retains 25% of the columns, but they may
-                not be spaced evenly.
-        """
-        if len(center_fractions) != len(accelerations):
-            raise ValueError('Number of center fractions should match number of accelerations')
-
-        self.center_fractions = center_fractions
-        self.accelerations = accelerations
-        self.rng = np.random.RandomState()
-
     def __call__(self, shape, seed):
         """
         Args:
@@ -138,34 +141,30 @@ class EquispacedMaskFunc():
         Returns:
             torch.Tensor: A mask of the specified shape.
         """
-       if len(shape) < 3:
+        if len(shape) < 3:
            raise ValueError('Shape should have 3 or more dimensions')
 
-       self.rng.seed(seed)
-       num_cols = shape[-2]
+        self.rng.seed(seed)
+        center_fraction, acceleration = self.choose_acceleration()
+        num_cols = shape[-2]
+        num_low_freqs = int(round(num_cols * center_fraction))
 
-       choice = self.rng.randint(0, len(self.accelerations))
-       center_fraction = self.center_fractions[choice]
-       acceleration = self.accelerations[choice]
-       num_cols = shape[-2]
-       num_low_freqs = int(round(num_cols * center_fraction))
+        # Create the mask
+        mask = np.zeros(num_cols, dtype=np.float32)
+        pad = (num_cols - num_low_freqs + 1) // 2
+        mask[pad:pad + num_low_freqs] = True
 
-       # Create the mask
-       mask = np.zeros(num_cols, dtype=np.float32)
-       pad = (num_cols - num_low_freqs + 1) // 2
-       mask[pad:pad + num_low_freqs] = True
+        # Determine acceleration rate by adjusting for the number of low frequencies
+        adjusted_accel = (acceleration * (num_low_freqs - num_cols)) / (num_low_freqs * acceleration - num_cols)
+        offset = self.rng.randint(0, round(adjusted_accel))
 
-       # Determine acceleration rate by adjusting for the number of low frequencies
-       adjusted_accel = (acceleration * (num_low_freqs - num_cols)) / (num_low_freqs * acceleration - num_cols)
-       offset = self.rng.randint(0, round(adjusted_accel))
+        accel_samples = np.arange(offset, num_cols - 1, adjusted_accel)
+        accel_samples = np.around(accel_samples).astype(np.uint)
+        mask[accel_samples] = True
 
-       accel_samples = np.arange(offset, num_cols - 1, adjusted_accel)
-       accel_samples = np.around(accel_samples).astype(np.uint)
-       mask[accel_samples] = True
+        # Reshape the mask
+        mask_shape = [1 for _ in shape]
+        mask_shape[-2] = num_cols
+        mask = torch.from_numpy(mask.reshape(*mask_shape).astype(np.float32))
 
-       # Reshape the mask
-       mask_shape = [1 for _ in shape]
-       mask_shape[-2] = num_cols
-       mask = torch.from_numpy(mask.reshape(*mask_shape).astype(np.float32))
-
-       return mask
+        return mask

--- a/common/test_subsample.py
+++ b/common/test_subsample.py
@@ -9,15 +9,15 @@ import numpy as np
 import pytest
 import torch
 
-from common.subsample import MaskFunc
+from common.subsample import RandomMaskFunc
 
 
 @pytest.mark.parametrize("center_fracs, accelerations, batch_size, dim", [
     ([0.2], [4], 4, 320),
     ([0.2, 0.4], [4, 8], 2, 368),
 ])
-def test_mask_reuse(center_fracs, accelerations, batch_size, dim):
-    mask_func = MaskFunc(center_fracs, accelerations)
+def test_random_mask_reuse(center_fracs, accelerations, batch_size, dim):
+    mask_func = RandomMaskFunc(center_fracs, accelerations)
     shape = (batch_size, dim, dim, 2)
     mask1 = mask_func(shape, seed=123)
     mask2 = mask_func(shape, seed=123)
@@ -30,8 +30,8 @@ def test_mask_reuse(center_fracs, accelerations, batch_size, dim):
     ([0.2], [4], 4, 320),
     ([0.2, 0.4], [4, 8], 2, 368),
 ])
-def test_mask_low_freqs(center_fracs, accelerations, batch_size, dim):
-    mask_func = MaskFunc(center_fracs, accelerations)
+def test_random_mask_low_freqs(center_fracs, accelerations, batch_size, dim):
+    mask_func = RandomMaskFunc(center_fracs, accelerations)
     shape = (batch_size, dim, dim, 2)
     mask = mask_func(shape, seed=123)
     mask_shape = [1 for _ in shape]

--- a/data/README.md
+++ b/data/README.md
@@ -63,7 +63,7 @@ from common import subsample
 from data import transforms, mri_data
 
 # Create a mask function
-mask_func = subsample.MaskFunc(center_fractions=[0.08, 0.04], accelerations=[4, 8])
+mask_func = subsample.RandomMaskFunc(center_fractions=[0.08, 0.04], accelerations=[4, 8])
 
 def data_transform(kspace, target, data_attributes, filename, slice_num):
     # Transform the data into appropriate format

--- a/data/test_transforms.py
+++ b/data/test_transforms.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 from common import utils
-from common.subsample import MaskFunc
+from common.subsample import RandomMaskFunc
 from data import transforms
 
 
@@ -25,7 +25,7 @@ def create_input(shape):
     ([2, 64, 64, 2], [0.04, 0.08], [8, 4]),
 ])
 def test_apply_mask(shape, center_fractions, accelerations):
-    mask_func = MaskFunc(center_fractions, accelerations)
+    mask_func = RandomMaskFunc(center_fractions, accelerations)
     expected_mask = mask_func(shape, seed=123)
     input = create_input(shape)
     output, mask = transforms.apply_mask(input, mask_func, seed=123)

--- a/fastMRI_tutorial.ipynb
+++ b/fastMRI_tutorial.ipynb
@@ -250,8 +250,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from common.subsample import MaskFunc\n",
-    "mask_func = MaskFunc(center_fractions=[0.04], accelerations=[8])  # Create the mask function object"
+    "from common.subsample import RandomMaskFunc\n",
+    "mask_func = RandomMaskFunc(center_fractions=[0.04], accelerations=[8])  # Create the mask function object"
    ]
   },
   {

--- a/models/cs/README.md
+++ b/models/cs/README.md
@@ -1,10 +1,10 @@
 ## Compressed Sensing with Total Variation Minimization
 
-This directory contains code to apply the ESPIRiT algorithm for coil sensitivity 
-estimation and Total Variation minimization based reconstruction using the 
+This directory contains code to apply the ESPIRiT algorithm for coil sensitivity
+estimation and Total Variation minimization based reconstruction using the
 BART toolkit.
 
-To install BART, please follow the installation instructions at 
+To install BART, please follow the installation instructions at
 https://mrirecon.github.io/bart/.
 
 Once BART is installed, set the `TOOLBOX_PATH` environment variable and point
@@ -17,10 +17,11 @@ export PYTHONPATH=${TOOLBOX_PATH}/python:${PYTHONPATH}
 
 To run the reconstruction algorithm on the validation data, run:
 ```bash
-python models/cs/run_bart_val.py --challenge CHALLENGE --data-path DATA --output-path reconstructions_val --reg-wt 0.01
+python models/cs/run_bart_val.py --challenge CHALLENGE --data-path DATA --output-path reconstructions_val --reg-wt 0.01 --mask-type MASK_TYPE
 ```
-where `CHALLENGE` is either `singlecoil` or `multicoil`. The outputs are saved in a directory called 
-`reconstructions_val`. To evaluate the results, run:
+where `CHALLENGE` is either `singlecoil` or `multicoil`. And `MASK_TYPE` is either `random` (for knee)
+or `equispaced` (for brain). The outputs are saved in a directory called `reconstructions_val`. To 
+evaluate the results, run:
 ```bash
 python common/evaluate.py --target-path TARGET_DATA --predictions-path reconstructions_val --challenge CHALLENGE
 ```
@@ -28,6 +29,6 @@ python common/evaluate.py --target-path TARGET_DATA --predictions-path reconstru
 To apply the reconstruction algorithm to the test data, run:
 ```bash
 python models/cs/run_bart_test.py --challenge CHALLENGE --data-path DATA --output-path reconstructions_test
-``` 
+```
 The outputs will be saved to `reconstructions_test` directory which can be uploaded for submission.
 

--- a/models/cs/run_bart_test.py
+++ b/models/cs/run_bart_test.py
@@ -38,14 +38,34 @@ REG_PARAM = {
     },
 
     'multicoil': {
-        'CORPD_FBK': {
-            4: 0.01,
-            8: 0.01
-        },
-        'CORPDFS_FBK': {
-            4: 0.001,
-            8: 0.01
-        },
+       'CORPD_FBK': {
+           4: 0.01,
+           8: 0.01,
+       },
+       'CORPDFS_FBK': {
+           4: 0.001,
+           8: 0.01,
+       },
+       'AXT1': {
+           4: 0.001,
+           8: 0.01,
+       },
+       'AXT1PRE': {
+           4: 0.001,
+           8: 0.01,
+       },
+       'AXT1POST': {
+           4: 0.01,
+           8: 0.01,
+       },
+       'AXT2': {
+           4: 0.01,
+           8: 0.01,
+       },
+       'AXFLAIR': {
+           4: 0.01,
+           8: 0.001,
+       },
     },
 }
 
@@ -94,7 +114,7 @@ def cs_total_variation(args, kspace, acquisition, acceleration, num_low_freqs):
     reconstruction algorithm using the BART toolkit.
     """
 
-    if acquisition not in {'CORPD_FBK', 'CORPDFS_FBK'}:
+    if acquisition not in REG_PARAM[args.challenge]:
         raise ValueError(f'Invalid acquisition protocol: {acquisition}')
     if acceleration not in {4, 8}:
         raise ValueError(f'Invalid acceleration factor: {acceleration}')
@@ -112,8 +132,10 @@ def cs_total_variation(args, kspace, acquisition, acceleration, num_low_freqs):
     pred = bart.bart(1, f'pics -d0 -S -R T:7:0:{reg_wt} -i {args.num_iters}', kspace, sens_maps)
     pred = torch.from_numpy(np.abs(pred[0]))
 
-    # Crop the predicted image to the correct size
-    return transforms.center_crop(pred, (args.resolution, args.resolution))
+    # Crop the predicted image to selected resolution if bigger
+    smallest_width = min(args.resolution, pred.shape[-1])
+    smallest_height = min(args.resolution, pred.shape[-2])
+    return transforms.center_crop(pred, (smallest_height, smallest_width))
 
 
 def run_model(i):

--- a/models/cs/run_bart_test.py
+++ b/models/cs/run_bart_test.py
@@ -38,30 +38,44 @@ REG_PARAM = {
     },
 
     'multicoil': {
+
+        # Knee
        'CORPD_FBK': {
            4: 0.01,
            8: 0.01,
        },
+
+        # Knee
        'CORPDFS_FBK': {
            4: 0.001,
            8: 0.01,
        },
+
+        # Brain
        'AXT1': {
            4: 0.001,
            8: 0.01,
        },
+
+        # Brain
        'AXT1PRE': {
            4: 0.001,
            8: 0.01,
        },
+
+        # Brain
        'AXT1POST': {
            4: 0.01,
            8: 0.01,
        },
+
+        # Brain
        'AXT2': {
            4: 0.01,
            8: 0.01,
        },
+
+        # Brain
        'AXFLAIR': {
            4: 0.01,
            8: 0.001,

--- a/models/cs/run_bart_val.py
+++ b/models/cs/run_bart_val.py
@@ -18,7 +18,7 @@ import torch
 import bart
 from common import utils
 from common.args import Args
-from common.subsample import mask_for_mask_type
+from common.subsample import create_mask_for_mask_type
 from common.utils import tensor_to_complex_np
 from data import transforms
 from data.mri_data import SliceData
@@ -63,7 +63,7 @@ class DataTransform:
 
 
 def create_data_loader(args):
-    dev_mask = mask_for_mask_type(args.mask_type, args.center_fractions, args.accelerations)
+    dev_mask = create_mask_for_mask_type(args.mask_type, args.center_fractions, args.accelerations)
     data = SliceData(
         root=args.data_path / f'{args.challenge}_val',
         transform=DataTransform(dev_mask),

--- a/models/cs/run_bart_val.py
+++ b/models/cs/run_bart_val.py
@@ -18,7 +18,7 @@ import torch
 import bart
 from common import utils
 from common.args import Args
-from common.subsample import MaskFunc
+from common.subsample import mask_for_mask_type
 from common.utils import tensor_to_complex_np
 from data import transforms
 from data.mri_data import SliceData
@@ -63,7 +63,7 @@ class DataTransform:
 
 
 def create_data_loader(args):
-    dev_mask = MaskFunc(args.center_fractions, args.accelerations)
+    dev_mask = mask_for_mask_type(args.mask_type, args.center_fractions, args.accelerations)
     data = SliceData(
         root=args.data_path / f'{args.challenge}_val',
         transform=DataTransform(dev_mask),
@@ -93,8 +93,10 @@ def cs_total_variation(args, kspace):
     )
     pred = torch.from_numpy(np.abs(pred[0]))
 
-    # Crop the predicted image to the correct size
-    return transforms.center_crop(pred, (args.resolution, args.resolution))
+    # Crop the predicted image to selected resolution if bigger
+    smallest_width = min(args.resolution, pred.shape[-1])
+    smallest_height = min(args.resolution, pred.shape[-2])
+    return transforms.center_crop(pred, (smallest_height, smallest_width))
 
 
 def run_model(i):

--- a/models/unet/README.md
+++ b/models/unet/README.md
@@ -5,13 +5,14 @@ in PyTorch.
 
 To start training the model, run:
 ```bash
-python models/unet/train_unet.py --challenge CHALLENGE --data-path DATA --exp-dir checkpoint
+python models/unet/train_unet.py --challenge CHALLENGE --data-path DATA --exp-dir checkpoint --mask-type MASK_TYPE
 ```
-where `CHALLENGE` is either `singlecoil` or `multicoil`.
+where `CHALLENGE` is either `singlecoil` or `multicoil`. And `MASK_TYPE` is either `random` (for knee)
+or `equispaced` (for brain).
 
 To run the model on validation data:
 ```bash
-python models/unet/run_unet.py --data-path DATA --data-split val --checkpoint checkpoint/best_model.pt --challenge CHALLENGE --out-dir reconstructions_val --mask-kspace
+python models/unet/run_unet.py --data-path DATA --data-split val --checkpoint checkpoint/best_model.pt --challenge CHALLENGE --out-dir reconstructions_val --mask-kspace --mask-type MASK_TYPE
 ```
 The outputs will be saved to `reconstructions_val`. To evaluate the results, run:
 ```bash

--- a/models/unet/run_unet.py
+++ b/models/unet/run_unet.py
@@ -14,7 +14,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from common.args import Args
-from common.subsample import mask_for_mask_type
+from common.subsample import create_mask_for_mask_type
 from common.utils import save_reconstructions
 from data import transforms
 from data.mri_data import SliceData
@@ -82,7 +82,7 @@ class DataTransform:
 def create_data_loaders(args):
     mask_func = None
     if args.mask_kspace:
-        mask_func = mask_for_mask_type(args.mask_type, args.center_fractions, args.accelerations)
+        mask_func = create_mask_for_mask_type(args.mask_type, args.center_fractions, args.accelerations)
     data = SliceData(
         root=args.data_path / f'{args.challenge}_{args.data_split}',
         transform=DataTransform(args.resolution, args.challenge, mask_func),

--- a/models/unet/train_unet.py
+++ b/models/unet/train_unet.py
@@ -19,7 +19,7 @@ from torch.nn import functional as F
 from torch.utils.data import DataLoader
 
 from common.args import Args
-from common.subsample import mask_for_mask_type
+from common.subsample import create_mask_for_mask_type
 from data import transforms
 from data.mri_data import SliceData
 from models.unet.unet_model import UnetModel
@@ -98,8 +98,8 @@ class DataTransform:
 
 
 def create_datasets(args):
-    train_mask = mask_for_mask_type(args.mask_type, args.center_fractions, args.accelerations)
-    dev_mask = mask_for_mask_type(args.mask_type, args.center_fractions, args.accelerations)
+    train_mask = create_mask_for_mask_type(args.mask_type, args.center_fractions, args.accelerations)
+    dev_mask = create_mask_for_mask_type(args.mask_type, args.center_fractions, args.accelerations)
 
     train_data = SliceData(
         root=args.data_path / f'{args.challenge}_train',

--- a/models/unet/unet_model.py
+++ b/models/unet/unet_model.py
@@ -110,6 +110,7 @@ class UnetModel(nn.Module):
         """
         stack = []
         output = input
+
         # Apply down-sampling layers
         for layer in self.down_sample_layers:
             output = layer(output)
@@ -120,7 +121,9 @@ class UnetModel(nn.Module):
 
         # Apply up-sampling layers
         for layer in self.up_sample_layers:
-            output = F.interpolate(output, scale_factor=2, mode='bilinear', align_corners=False)
-            output = torch.cat([output, stack.pop()], dim=1)
+            downsample_layer = stack.pop()
+            layer_size = (downsample_layer.shape[-2], downsample_layer.shape[-1])
+            output = F.interpolate(output, size=layer_size, mode='bilinear', align_corners=False)
+            output = torch.cat([output, downsample_layer], dim=1)
             output = layer(output)
         return self.conv2(output)

--- a/models/zero_filled/run_zero_filled.py
+++ b/models/zero_filled/run_zero_filled.py
@@ -23,7 +23,9 @@ def save_zero_filled(data_dir, out_dir, which_challenge, resolution):
             # Inverse Fourier Transform to get zero filled solution
             image = transforms.ifft2(masked_kspace)
             # Crop input image
-            image = transforms.complex_center_crop(image, (resolution, resolution))
+            smallest_width = min(resolution, image.shape[-2])
+            smallest_height = min(resolution, image.shape[-3])
+            image = transforms.complex_center_crop(image, (smallest_height, smallest_width))
             # Absolute value
             image = transforms.complex_abs(image)
             # Apply Root-Sum-of-Squares if multicoil data


### PR DESCRIPTION
This PR adds support for the upcoming brain dataset. Specifically it adds:
- Handling of arbitrary sized kspace and target images (in dataloaders and UNet model)
- Adding equispaced masks, which can be chosen with a command line argument
- Hard coding best regularization weights for each brain sequence type when using TV.