### PR TITLE
Fixed SSIM evaluation bug

### DIFF
--- a/fastmri/mri_module.py
+++ b/fastmri/mri_module.py
@@ -213,8 +213,8 @@ class MriModule(pl.LightningModule):
         # handle aggregation for distributed case with pytorch_lightning metrics
         metrics = dict(val_loss=0, nmse=0, ssim=0, psnr=0)
         for fname in outputs:
-            output = torch.cat([out for _, out in sorted(outputs[fname])]).numpy()
-            target = torch.cat([tgt for _, tgt in sorted(targets[fname])]).numpy()
+            output = torch.stack([out for _, out in sorted(outputs[fname])]).numpy()
+            target = torch.stack([tgt for _, tgt in sorted(targets[fname])]).numpy()
             metrics["nmse"] = metrics["nmse"] + evaluate.nmse(target, output)
             metrics["ssim"] = metrics["ssim"] + evaluate.ssim(target, output)
             metrics["psnr"] = metrics["psnr"] + evaluate.psnr(target, output)


### PR DESCRIPTION
There was a bug in validation_epoch_end in the `MriModule` where the slices were concatenated along a spatial dimension instead of a new slice dimension. `evaluate.ssim` operated on these single concatenated slices instead of volumes and therefore there was no averaging along the slice dimension. 