### PR TITLE
Fixed experiment random seed for proper ddp subsampling

### DIFF
--- a/experimental/unet/train_unet_demo.py
+++ b/experimental/unet/train_unet_demo.py
@@ -9,7 +9,7 @@ import pathlib
 import sys
 from argparse import ArgumentParser
 
-from pytorch_lightning import Trainer
+from pytorch_lightning import Trainer, seed_everything
 
 sys.path.append("../../")  # noqa: E402
 
@@ -22,8 +22,8 @@ def main(args):
     # ------------------------
     # 1 INIT LIGHTNING MODEL
     # ------------------------
+    seed_everything(args.seed)
     model = UnetModule(**vars(args))
-
     # ------------------------
     # 2 INIT TRAINER
     # ------------------------
@@ -86,10 +86,11 @@ def build_args():
         default_root_dir=logdir,
         replace_sampler_ddp=(backend != "ddp"),
         distributed_backend=backend,
+        deterministic=True,
     )
 
     parser.add_argument("--mode", default="train", type=str)
-
+    parser.add_argument("--seed", default=42, type=int)
     args = parser.parse_args()
 
     return args

--- a/experimental/unet/train_unet_demo.py
+++ b/experimental/unet/train_unet_demo.py
@@ -24,6 +24,7 @@ def main(args):
     # ------------------------
     seed_everything(args.seed)
     model = UnetModule(**vars(args))
+    
     # ------------------------
     # 2 INIT TRAINER
     # ------------------------
@@ -90,7 +91,6 @@ def build_args():
     )
 
     parser.add_argument("--mode", default="train", type=str)
-    parser.add_argument("--seed", default=42, type=int)
     args = parser.parse_args()
 
     return args

--- a/experimental/varnet/train_varnet_demo.py
+++ b/experimental/varnet/train_varnet_demo.py
@@ -9,7 +9,7 @@ import pathlib
 import sys
 from argparse import ArgumentParser
 
-from pytorch_lightning import Trainer
+from pytorch_lightning import Trainer, seed_everything
 
 sys.path.append("../../")  # noqa: E402
 
@@ -22,6 +22,7 @@ def main(args):
     # ------------------------
     # 1 INIT LIGHTNING MODEL
     # ------------------------
+    seed_everything(args.seed)
     model = VarNetModule(**vars(args))
 
     # ------------------------
@@ -78,6 +79,7 @@ def build_args():
         exp_name="varnet_demo",
         test_split="test",
         batch_size=batch_size,
+        deterministic=True,
     )
     parser.set_defaults(**config)
 

--- a/experimental/varnet/train_varnet_demo.py
+++ b/experimental/varnet/train_varnet_demo.py
@@ -79,7 +79,6 @@ def build_args():
         exp_name="varnet_demo",
         test_split="test",
         batch_size=batch_size,
-        deterministic=True,
     )
     parser.set_defaults(**config)
 
@@ -88,10 +87,10 @@ def build_args():
         default_root_dir=logdir,
         replace_sampler_ddp=(backend != "ddp"),
         distributed_backend=backend,
+        deterministic=True,
     )
 
     parser.add_argument("--mode", default="train", type=str)
-
     args = parser.parse_args()
 
     return args

--- a/fastmri/mri_module.py
+++ b/fastmri/mri_module.py
@@ -278,6 +278,10 @@ class MriModule(pl.LightningModule):
         parser.add_argument(
             "--num_workers", default=4, type=float,
         )
+        parser.add_argument(
+            "--seed", default=42, type=int,
+        )
+
 
         # logging params
         parser.add_argument(


### PR DESCRIPTION
The random seed of `SliceDataset` has not been explicitly set on the experiment level. Different processes during ddp training had different random seed. This led to different parts of the training data selected by different workers if `args.sub_sample < 1`.  Now the default behavior in unet/varnet experiments is `deterministic` and the same portion of data is selected by processes.