### PR TITLE
Adding an equispaced mask comment

### DIFF
--- a/fastmri/data/subsample.py
+++ b/fastmri/data/subsample.py
@@ -130,6 +130,11 @@ class EquispacedMaskFunc(MaskFunc):
     It is possible to use multiple center_fractions and accelerations, in which
     case one possible (center_fraction, acceleration) is chosen uniformly at
     random each time the EquispacedMaskFunc object is called.
+
+    Note that this function may not give equispaced samples (documented in
+    https://github.com/facebookresearch/fastMRI/issues/54), which will require
+    modifications to standard GRAPPA approaches. Nonetheless, this aspect of
+    the function has been preserved to match the public multicoil data. 
     """
 
     def __call__(self, shape, seed):


### PR DESCRIPTION
This adds a comment to the documentation of the equispaced mask function that it doesn't not generate perfectly equispaced masks as mentioned in Issue #54.