### PR TITLE
Fixed ismrmrd in requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,10 @@ We have tested this code using:
 
 You can find the full list of Python packages needed to run the code in the `requirements.txt` file. Most people already have their own PyTorch environment configured with Anaconda, and based on `requirements.txt` you can install the final packages as needed.
 
-If you want to install with `pip`, first delete the `git+https://github.com/ismrmrd/ismrmrd-python.git` line from `requirements.txt`. Then, run
+If you want to install with `pip`, run
 
 ```bash
 pip install -r requirements.txt
-```
-
-Finally, run
-
-```bash
-pip install git+https://github.com/ismrmrd/ismrmrd-python.git
 ```
 
 Then you should have all the packages.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ h5py>=2.10.0
 PyYAML>=5.3.1
 pytest>=5.4.3
 pyxb==1.2.6
-git+https://github.com/ismrmrd/ismrmrd-python.git
+ismrmrd@git+https://github.com/ismrmrd/ismrmrd-python.git


### PR DESCRIPTION
This works with the requirements.txt of my active acquisition project, and afterwards I can do `import ismrmrd` without issues. Can you also test this on your side?

I'm using
pip 20.2.3
setuptools 49.6.0