### PR TITLE
Add setup.py and new installation instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ logs
 *.png
 *.cfl
 *.hdr
+*egg-info*
 recon-workspace.code-workspace
 datasets/
 logs/

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We have tested this code using:
 * CUDA 10.1
 * CUDNN 7.6.5
 
-First install PyTorch according to the directions at the [PyTorch Website](https://pytorch.org/) for your operating system and CUDA setup.
+First install PyTorch according to the directions at the [PyTorch Website](https://pytorch.org/get-started/) for your operating system and CUDA setup.
 
 Then, navigate to the `fastmri` root directory and run
 

--- a/README.md
+++ b/README.md
@@ -55,21 +55,15 @@ We have tested this code using:
 * CUDA 10.1
 * CUDNN 7.6.5
 
-You can find the full list of Python packages needed to run the code in the `requirements.txt` file. Most people already have their own PyTorch environment configured with Anaconda, and based on `requirements.txt` you can install the final packages as needed.
+First install PyTorch according to the directions at the [PyTorch Website](https://pytorch.org/) for your operating system and CUDA setup.
 
-If you want to install with `pip`, first delete the `git+https://github.com/ismrmrd/ismrmrd-python.git` line from `requirements.txt`. Then, run
-
-```bash
-pip install -r requirements.txt
-```
-
-Finally, run
+Then, navigate to the `fastmri` root directory and run
 
 ```bash
-pip install git+https://github.com/ismrmrd/ismrmrd-python.git
+pip install -e .
 ```
 
-Then you should have all the packages.
+`pip` will handle all package dependencies. After this you should be able to run most the code in the repository.
 
 ## Directory Structure & Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scikit_image>=0.16.2
 torchvision>=0.6.0
 torch>=1.5.1
 runstats>=1.8.0
-pytorch_lightning>=0.8.5
+pytorch_lightning==0.8.5
 h5py>=2.10.0
 PyYAML>=5.3.1
 pytest>=5.4.3

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import subprocess
+import sys
+
+from setuptools import find_packages, setup
+
+install_requires = [
+    "numpy>=1.18.5",
+    "scikit_image>=0.16.2",
+    "torchvision>=0.6.0",
+    "torch>=1.5.1",
+    "runstats>=1.8.0",
+    "pytorch_lightning==0.8.5",
+    "h5py",
+    "PyYAML",
+    "pytest",
+    "pyxb",
+    "ismrmrd @ git+https://github.com/ismrmrd/ismrmrd-python.git",
+]
+
+# pyxb not properly handled in ismrmrd - this prevents installation breakage
+# should install into user environment that launched install script
+subprocess.check_call([sys.executable, "-m", "pip", "install", "pyxb"])
+
+setup(
+    name="fastmri",
+    author="Facebook/NYU fastMRI Team",
+    author_email="fastmri@fb.com",
+    version="0.1",
+    packages=find_packages(
+        exclude=["tests", "experimental", "data", "common", "banding_removal", "models"]
+    ),
+    setup_requires=["wheel"],
+    install_requires=install_requires,
+)


### PR DESCRIPTION
This adds a `setup.py` file for installation configuration. It removes the old nasty two-step process to separately install `pyxb` and `ismrmrd`. It will also allow us to remove all `sys.path.append` commands throughout the repository.

Test plan:
```bash
conda create -n fastmri_test
conda activate fastmri_test
conda install anaconda
conda install pytorch torchvision cudatoolkit=10.1 -c pytorch
pip install -e .
python -c "import ismrmrd; import fastmri"
```

All of this should run without failure.