### PR TITLE
Update logging for PyTorch Lightning 1.0.0

### DIFF
--- a/experimental/unet/train_unet_demo.py
+++ b/experimental/unet/train_unet_demo.py
@@ -6,29 +6,26 @@ LICENSE file in the root directory of this source tree.
 """
 
 import pathlib
-import sys
 from argparse import ArgumentParser
 
-from pytorch_lightning import Trainer, seed_everything
-
-sys.path.append("../../")  # noqa: E402
-
+import fastmri
+import pytorch_lightning as pl
 from fastmri.data.mri_data import fetch_dir
-from unet_module import UnetModule
+from fastmri.pl_modules import UnetModule, configure_checkpoint
 
 
-def main(args):
+def cli_main(args):
     """Main training routine."""
     # ------------------------
     # 1 INIT LIGHTNING MODEL
     # ------------------------
-    seed_everything(args.seed)
+    pl.seed_everything(args.seed)
     model = UnetModule(**vars(args))
 
     # ------------------------
     # 2 INIT TRAINER
     # ------------------------
-    trainer = Trainer.from_argparse_args(args)
+    trainer = pl.Trainer.from_argparse_args(args)
 
     # ------------------------
     # 3 START TRAINING OR TEST
@@ -37,7 +34,8 @@ def main(args):
         trainer.fit(model)
     elif args.mode == "test":
         assert args.resume_from_checkpoint is not None
-        trainer.test(model)
+        outputs = trainer.test(model)
+        fastmri.save_reconstructions(outputs, args.default_root_dir / "reconstructions")
     else:
         raise ValueError(f"unrecognized mode {args.mode}")
 
@@ -48,16 +46,18 @@ def build_args():
     # ------------------------
     path_config = pathlib.Path.cwd() / ".." / ".." / "fastmri_dirs.yaml"
     knee_path = fetch_dir("knee_path", path_config)
-    logdir = fetch_dir("log_path", path_config) / "unet" / "unet_demo"
+    default_root_dir = fetch_dir("log_path", path_config) / "unet" / "unet_demo"
 
     parent_parser = ArgumentParser(add_help=False)
 
     parser = UnetModule.add_model_specific_args(parent_parser)
-    parser = Trainer.add_argparse_args(parser)
+    parser = pl.Trainer.add_argparse_args(parser)
 
     num_gpus = 2
     backend = "ddp"
     batch_size = 1 if backend == "ddp" else num_gpus
+
+    checkpoint_callback, resume_from_checkpoint = configure_checkpoint(default_root_dir)
 
     # module config
     config = dict(
@@ -75,18 +75,19 @@ def build_args():
         weight_decay=0.0,
         data_path=knee_path,
         challenge="singlecoil",
-        exp_dir=logdir,
-        exp_name="unet_demo",
         test_split="test",
         batch_size=batch_size,
+        sample_rate=1.0,
     )
     parser.set_defaults(**config)
 
     # trainer config
     parser.set_defaults(
+        default_root_dir=default_root_dir,
+        checkpoint_callback=checkpoint_callback,
+        resume_from_checkpoint=resume_from_checkpoint,
         gpus=num_gpus,
-        default_root_dir=logdir,
-        replace_sampler_ddp=(backend != "ddp"),
+        replace_sampler_ddp=False,
         distributed_backend=backend,
         seed=42,
         deterministic=True,
@@ -104,7 +105,7 @@ def run_cli():
     # ---------------------
     # RUN TRAINING
     # ---------------------
-    main(args)
+    cli_main(args)
 
 
 if __name__ == "__main__":

--- a/fastmri/__init__.py
+++ b/fastmri/__init__.py
@@ -19,5 +19,4 @@ from .math import (
     roll,
     tensor_to_complex_np,
 )
-from .mri_module import MriModule
 from .utils import save_reconstructions

--- a/fastmri/evaluate.py
+++ b/fastmri/evaluate.py
@@ -11,62 +11,10 @@ from argparse import ArgumentParser
 
 import h5py
 import numpy as np
-from pytorch_lightning.metrics.metric import NumpyMetric, TensorMetric
 from runstats import Statistics
 from skimage.metrics import peak_signal_noise_ratio, structural_similarity
-from torch.distributed import ReduceOp
 
 from fastmri.data import transforms
-
-
-class MSE(NumpyMetric):
-    """Calculates MSE and aggregates by summing across distr processes."""
-
-    def __init__(self, name="MSE", *args, **kwargs):
-        super().__init__(name=name, *args, **kwargs)
-
-    def forward(self, gt, pred):
-        return mse(gt, pred)
-
-
-class NMSE(NumpyMetric):
-    """Calculates NMSE and aggregates by summing across distr processes."""
-
-    def __init__(self, name="NMSE", *args, **kwargs):
-        super().__init__(name=name, *args, **kwargs)
-
-    def forward(self, gt, pred):
-        return nmse(gt, pred)
-
-
-class PSNR(NumpyMetric):
-    """Calculates PSNR and aggregates by summing across distr processes."""
-
-    def __init__(self, name="PSNR", *args, **kwargs):
-        super().__init__(name=name, *args, **kwargs)
-
-    def forward(self, gt, pred):
-        return psnr(gt, pred)
-
-
-class SSIM(NumpyMetric):
-    """Calculates SSIM and aggregates by summing across distr processes."""
-
-    def __init__(self, name="SSIM", *args, **kwargs):
-        super().__init__(name=name, *args, **kwargs)
-
-    def forward(self, gt, pred, maxval=None):
-        return ssim(gt, pred, maxval=maxval)
-
-
-class DistributedMetricSum(TensorMetric):
-    """Used for summing parameters across distr processes."""
-
-    def __init__(self, name="DistributedMetricSum", *args, **kwargs):
-        super().__init__(name=name, *args, **kwargs)
-
-    def forward(self, x):
-        return x.clone()
 
 
 def mse(gt, pred):

--- a/fastmri/pl_modules/__init__.py
+++ b/fastmri/pl_modules/__init__.py
@@ -1,0 +1,4 @@
+from .configure_checkpoint import configure_checkpoint
+from .mri_module import MriModule
+from .unet_module import UnetModule
+from .varnet_module import VarNetModule

--- a/fastmri/pl_modules/configure_checkpoint.py
+++ b/fastmri/pl_modules/configure_checkpoint.py
@@ -26,9 +26,9 @@ def configure_checkpoint(
         (tuple): Tuple containing:
             pl.callbacks.ModelCheckpoint: A ModelCheckpooint for a PyTorch
                 Lightning Trainer.
-            pathlib.Path: A checkpoint you can pass to resume_from_checkpoint
-                in the trainer to resume existing training. If no checkpoint is
-                found, this returns None.
+            str: A checkpoint you can pass to resume_from_checkpoint in the
+                trainer to resume existing training. If no checkpoint is found,
+                this returns None.
     """
     checkpoint_dir = default_root_dir / checkpoint_name
 
@@ -36,7 +36,7 @@ def configure_checkpoint(
     if checkpoint_dir.exists():
         ckpt_list = sorted(checkpoint_dir.glob("*.ckpt"), key=os.path.getmtime)
         if ckpt_list:
-            resume_from_checkpoint = ckpt_list[-1]
+            resume_from_checkpoint = str(ckpt_list[-1])
     else:
         checkpoint_dir.mkdir()  # note: better to create this outside main
 

--- a/fastmri/pl_modules/configure_checkpoint.py
+++ b/fastmri/pl_modules/configure_checkpoint.py
@@ -45,7 +45,7 @@ def configure_checkpoint(
         save_top_k=True,
         verbose=True,
         monitor=monitor,
-        mode=min,
+        mode=mode,
         prefix="",
     )
 

--- a/fastmri/pl_modules/configure_checkpoint.py
+++ b/fastmri/pl_modules/configure_checkpoint.py
@@ -1,0 +1,52 @@
+import os
+import pytorch_lightning as pl
+
+
+def configure_checkpoint(
+    default_root_dir, checkpoint_name="checkpoints", monitor="val_loss", mode="min"
+):
+    """
+    Checkpoint configuration function.
+
+    This simple function sets up a pl.callbacks.ModelCheckpoint for logging
+    into default_root_dir / checkpoint_name. Prior to setting up the checkpoint
+    callback, it checks the directory for any existing checkpoints and returns
+    the most recent one. If default_root_dir / checkpoint_name does not exist,
+    then this function creates it.
+
+    Args:
+        default_root_dir (pathlib.Path): Default root directory for logging.
+        checkpoint_name (str, optional): Name for checkpoint subfolder.
+            Defaults to "checkpoints".
+        monitor (str, optional): Quantity to monitor for saving checkpoints.
+            Defaults to "val_loss".
+        mode (str, optional): Mode for monitoring. Defaults to "min".
+    
+    Returns:
+        (tuple): Tuple containing:
+            pl.callbacks.ModelCheckpoint: A ModelCheckpooint for a PyTorch
+                Lightning Trainer.
+            pathlib.Path: A checkpoint you can pass to resume_from_checkpoint
+                in the trainer to resume existing training. If no checkpoint is
+                found, this returns None.
+    """
+    checkpoint_dir = default_root_dir / checkpoint_name
+
+    resume_from_checkpoint = None
+    if checkpoint_dir.exists():
+        ckpt_list = sorted(checkpoint_dir.glob("*.ckpt"), key=os.path.getmtime)
+        if ckpt_list:
+            resume_from_checkpoint = ckpt_list[-1]
+    else:
+        checkpoint_dir.mkdir()  # note: better to create this outside main
+
+    checkpoint_callback = pl.callbacks.ModelCheckpoint(
+        filepath=default_root_dir / checkpoint_name,
+        save_top_k=True,
+        verbose=True,
+        monitor=monitor,
+        mode=min,
+        prefix="",
+    )
+
+    return checkpoint_callback, resume_from_checkpoint

--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -272,8 +272,8 @@ class MriModule(pl.LightningModule):
         outputs = defaultdict(list)
 
         for log in test_logs:
-            for i, (fname, slice) in enumerate(zip(log["fname"], log["slice"])):
-                outputs[fname].append((slice, log["output"][i]))
+            for i, (fname, slice_num) in enumerate(zip(log["fname"], log["slice"])):
+                outputs[fname].append((slice_num, log["output"][i]))
 
         for fname in outputs:
             outputs[fname] = np.stack([out for _, out in sorted(outputs[fname])])

--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -79,7 +79,6 @@ class MriModule(pl.LightningModule):
             num_workers (int, default=4): Number of workers for PyTorch dataloader.
         """
         super().__init__()
-        self.save_hyperparameters()
 
         self.data_path = data_path
         self.challenge = challenge

--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -182,6 +182,8 @@ class MriModule(pl.LightningModule):
         # log images to tensorboard
         if isinstance(val_logs["batch_idx"], int):
             batch_indices = [val_logs["batch_idx"]]
+        else:
+            batch_indices = val_logs["batch_idx"]
         for i, batch_idx in enumerate(batch_indices):
             if batch_idx in self.val_log_indices:
                 key = f"val_images_idx_{batch_idx}"

--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -160,16 +160,16 @@ class MriModule(pl.LightningModule):
         ):
             if k not in val_logs.keys():
                 raise RuntimeError(
-                    f"Expected key {k} in dict returned by validation_step."
+                    f"Expected key {k} in dict returned by validation_step"
                 )
         if val_logs["output"].ndim == 2:
             val_logs["output"] = val_logs["output"].unsqueeze(0)
         elif val_logs["output"].ndim != 3:
-            raise RuntimeError("Unexpected output size from validation_step.")
+            raise RuntimeError("Unexpected output size from validation_step")
         if val_logs["target"].ndim == 2:
             val_logs["target"] = val_logs["target"].unsqueeze(0)
         elif val_logs["target"].ndim != 3:
-            raise RuntimeError("Unexpected output size from validation_step.")
+            raise RuntimeError("Unexpected output size from validation_step")
 
         # pick a set of images to log if we don't have one already
         if self.val_log_indices is None:
@@ -180,10 +180,8 @@ class MriModule(pl.LightningModule):
             )
 
         # log images to tensorboard
-        if len(val_logs["output"]) == 1:
+        if isinstance(val_logs["batch_idx"], int):
             batch_indices = [val_logs["batch_idx"]]
-        else:
-            batch_indices = val_logs["bach_idx"]
         for i, batch_idx in enumerate(batch_indices):
             if batch_idx in self.val_log_indices:
                 key = f"val_images_idx_{batch_idx}"

--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -79,6 +79,7 @@ class MriModule(pl.LightningModule):
             num_workers (int, default=4): Number of workers for PyTorch dataloader.
         """
         super().__init__()
+        self.save_hyperparameters()
 
         self.data_path = data_path
         self.challenge = challenge

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 numpy>=1.18.5
 scikit_image>=0.16.2
 torchvision>=0.6.0
-torch>=1.5.1
+torch>=1.6
 runstats>=1.8.0
-pytorch_lightning==0.8.5
+pytorch_lightning>=1.0.0
 h5py>=2.10.0
 PyYAML>=5.3.1
 pytest>=5.4.3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "numpy>=1.18.5",
     "scikit_image>=0.16.2",
     "torchvision>=0.6.0",
-    "torch>=1.5.1",
+    "torch>=1.6",
     "runstats>=1.8.0",
     "pytorch_lightning",
     "h5py",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "torchvision>=0.6.0",
     "torch>=1.5.1",
     "runstats>=1.8.0",
-    "pytorch_lightning==0.8.5",
+    "pytorch_lightning",
     "h5py",
     "PyYAML",
     "pytest",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,15 +5,12 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-import pathlib
-
 import numpy as np
 import pytest
 import torch
-import yaml
 
 # these are really slow - skip by default
-skip_module_test_flag = True
+skip_module_test_flag = False
 skip_data_test_flag = True
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 """
 
 import pytest
-
 from fastmri.data.mri_data import CombinedSliceDataset, SliceDataset, fetch_dir
 
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -5,11 +5,10 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
+import fastmri
 import numpy as np
 import pytest
 import torch
-
-import fastmri
 from fastmri.data import transforms
 
 from .conftest import create_input

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,8 +6,6 @@ LICENSE file in the root directory of this source tree.
 """
 
 import pytest
-import torch
-
 from fastmri.data import transforms
 from fastmri.data.subsample import RandomMaskFunc
 from fastmri.models import Unet, VarNet

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -5,15 +5,12 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-import pathlib
 from argparse import ArgumentParser
 
 import pytest
-from pytorch_lightning import Trainer
-
-from experimental.unet.unet_module import UnetModule
-from experimental.varnet.varnet_module import VarNetModule
 from fastmri.data.mri_data import fetch_dir
+from fastmri.pl_modules import UnetModule, VarNetModule
+from pytorch_lightning import Trainer
 
 
 def build_unet_args():

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -13,9 +13,9 @@ from fastmri.pl_modules import UnetModule, VarNetModule
 from pytorch_lightning import Trainer
 
 
-def build_unet_args():
+def build_unet_args(tmp_path):
     knee_path = fetch_dir("knee_path")
-    logdir = fetch_dir("log_path") / "test_dir"
+    logdir = tmp_path / "unet_test_dir"
 
     parent_parser = ArgumentParser(add_help=False)
 
@@ -63,9 +63,9 @@ def build_unet_args():
     return args
 
 
-def build_varnet_args():
+def build_varnet_args(tmp_path):
     knee_path = fetch_dir("knee_path")
-    logdir = fetch_dir("log_path") / "test_dir"
+    logdir = tmp_path / "varnet_test_dir"
 
     parent_parser = ArgumentParser(add_help=False)
 
@@ -114,11 +114,11 @@ def build_varnet_args():
 
 
 @pytest.mark.parametrize("backend", [(None)])
-def test_unet_trainer(backend, skip_module_test):
+def test_unet_trainer(backend, skip_module_test, tmp_path):
     if skip_module_test:
         pytest.skip("config set to skip")
 
-    args = build_unet_args()
+    args = build_unet_args(tmp_path)
     args.fast_dev_run = True
     args.backend = backend
 
@@ -129,11 +129,11 @@ def test_unet_trainer(backend, skip_module_test):
 
 
 @pytest.mark.parametrize("backend", [(None)])
-def test_varnet_trainer(backend, skip_module_test):
+def test_varnet_trainer(backend, skip_module_test, tmp_path):
     if skip_module_test:
         pytest.skip("config set to skip")
 
-    args = build_varnet_args()
+    args = build_varnet_args(tmp_path)
     args.fast_dev_run = True
     args.backend = backend
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -7,10 +7,9 @@ LICENSE file in the root directory of this source tree.
 
 import numpy as np
 import pytest
-import torch
-
 from fastmri.data import transforms
 from fastmri.data.subsample import RandomMaskFunc
+
 from .conftest import create_input
 
 


### PR DESCRIPTION
This updates the logging components for PyTorch Lightning 1.0.0 - part of the Issue #84 roadmap.

This is a big update. Most importantly it does:

- Updates return values from `validation_step` so that only metrics are stored long-term. This should reduce memory consumption quite a bit during the validation loop. It also minimizes device management which should make NCCL a little more robust.
- Alters image logging in a way that is flexible for multiple image shapes. Also adds a new parameter for how many images to log.
- Adds a `max_value` to U-Net and VarNet transforms. This allows the computation of SSIM in `validation_step_end` without knowledge of all other slices in the volume.
- Homogenizes handling of experimental directories via `default_root_dir` in the main client script. 
- Saving of test output images also now handled in main client script.