### PR TITLE
Remove ismrmrd dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
       - run:
           name: Preinstallation Packages
           command: |
-            pip install pyxb
             pip install wheel
             pip install pytest
       - python/install-packages:

--- a/fastmri/data/mri_data.py
+++ b/fastmri/data/mri_data.py
@@ -9,13 +9,24 @@ import logging
 import pathlib
 import pickle
 import random
+import xml.etree.ElementTree as etree
 from warnings import warn
 
 import h5py
-import ismrmrd
 import numpy as np
 import torch
 import yaml
+
+
+def et_query(root, qlist, prefix="mrd"):
+    s = "."
+
+    for el in qlist:
+        s = s + f"//{prefix}:{el}"
+
+    namespace = {prefix: "http://www.ismrm.org/ISMRMRD"}
+
+    return root.find(s, namespace).text
 
 
 def fetch_dir(key, data_config_file=pathlib.Path("fastmri_dirs.yaml")):
@@ -162,24 +173,25 @@ class SliceDataset(torch.utils.data.Dataset):
             files = list(pathlib.Path(root).iterdir())
             for fname in sorted(files):
                 with h5py.File(fname, "r") as hf:
-                    hdr = ismrmrd.xsd.CreateFromDocument(hf["ismrmrd_header"][()])
-                    enc = hdr.encoding[0]
+                    et_root = etree.fromstring(hf["ismrmrd_header"][()])
 
+                    enc = ["encoding", "encodedSpace", "matrixSize"]
                     enc_size = (
-                        enc.encodedSpace.matrixSize.x,
-                        enc.encodedSpace.matrixSize.y,
-                        enc.encodedSpace.matrixSize.z,
+                        int(et_query(et_root, enc + ["x"])),
+                        int(et_query(et_root, enc + ["y"])),
+                        int(et_query(et_root, enc + ["z"])),
                     )
+                    rec = ["encoding", "reconSpace", "matrixSize"]
                     recon_size = (
-                        enc.reconSpace.matrixSize.x,
-                        enc.reconSpace.matrixSize.y,
-                        enc.reconSpace.matrixSize.z,
+                        int(et_query(et_root, rec + ["x"])),
+                        int(et_query(et_root, rec + ["y"])),
+                        int(et_query(et_root, rec + ["z"])),
                     )
 
-                    enc_limits_center = enc.encodingLimits.kspace_encoding_step_1.center
-                    enc_limits_max = (
-                        enc.encodingLimits.kspace_encoding_step_1.maximum + 1
-                    )
+                    lims = ["encoding", "encodingLimits", "kspace_encoding_step_1"]
+                    enc_limits_center = int(et_query(et_root, lims + ["center"]))
+                    enc_limits_max = int(et_query(et_root, lims + ["maximum"])) + 1
+
                     padding_left = enc_size[1] // 2 - enc_limits_center
                     padding_right = padding_left + enc_limits_max
 

--- a/fastmri/data/mri_data.py
+++ b/fastmri/data/mri_data.py
@@ -18,15 +18,30 @@ import torch
 import yaml
 
 
-def et_query(root, qlist, prefix="mrd"):
+def et_query(root, qlist, namespace="http://www.ismrm.org/ISMRMRD"):
+    """
+    ElementTree query function.
+
+    This can be used to query an xml document via ElementTree. It uses qlist
+    for nexted queries.
+
+    Args:
+        root (xml.etree.ElementTree.Element): Root of the xml.
+        qlist (Sequence): A list of strings for nested searches.
+        namespace (str): xml namespace.
+
+    Returns:
+        str: The retrieved data.
+    """
     s = "."
+    prefix = "ismrmrd_namespace"
+
+    ns = {prefix: namespace}
 
     for el in qlist:
         s = s + f"//{prefix}:{el}"
 
-    namespace = {prefix: "http://www.ismrm.org/ISMRMRD"}
-
-    return root.find(s, namespace).text
+    return root.find(s, ns).text
 
 
 def fetch_dir(key, data_config_file=pathlib.Path("fastmri_dirs.yaml")):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ runstats>=1.8.0
 pytorch_lightning>=1.0.0
 h5py>=2.10.0
 PyYAML>=5.3.1
-git+https://github.com/ismrmrd/ismrmrd-python.git

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@ install_requires = [
     "pytorch_lightning",
     "h5py",
     "PyYAML",
-    "pytest",
-    "ismrmrd @ git+https://github.com/ismrmrd/ismrmrd-python.git",
 ]
 
 setup(


### PR DESCRIPTION
This PR removes the ISMRMRD dependency. ISMRMRD depends on `pyxb`, which is at [end-of-life](https://github.com/pabigot/pyxb/issues/100). Removing this dependency should help stabilize the fastMRI repository for the long run.

There is only one place we need the `ismrmrd` Python package: to parse the xml header in the `.hf` files. This update replaces `ismrmrd` with `ElementTree`, which is part of the Python standard library. I've re-run all integration tests with this update and checked that the generated `dataset_cache.pkl` files have identical values vs. the old version.