### PR TITLE
Add dataset mocking

### DIFF
--- a/fastmri/pl_modules/unet_module.py
+++ b/fastmri/pl_modules/unet_module.py
@@ -114,7 +114,9 @@ class UnetModule(MriModule):
 
     def configure_optimizers(self):
         optim = torch.optim.RMSprop(
-            self.parameters(), lr=self.lr, weight_decay=self.weight_decay,
+            self.parameters(),
+            lr=self.lr,
+            weight_decay=self.weight_decay,
         )
         scheduler = torch.optim.lr_scheduler.StepLR(
             optim, self.lr_step_size, self.lr_gamma

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,10 @@ LICENSE file in the root directory of this source tree.
 import numpy as np
 import pytest
 import torch
+from .create_temp_data import create_temp_data
 
 # these are really slow - skip by default
-skip_module_test_flag = True
-skip_data_test_flag = True
+skip_integrations = True
 
 
 def create_input(shape):
@@ -21,14 +21,16 @@ def create_input(shape):
     return x
 
 
-@pytest.fixture
-def skip_module_test():
-    return skip_module_test_flag
+@pytest.fixture(scope="session")
+def fastmri_mock_dataset(tmp_path_factory):
+    path = tmp_path_factory.mktemp("fastmri_data")
+
+    return create_temp_data(path)
 
 
 @pytest.fixture
-def skip_data_test():
-    return skip_data_test_flag
+def skip_integration_tests():
+    return skip_integrations
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import torch
 from .create_temp_data import create_temp_data
 
 # these are really slow - skip by default
-skip_integrations = True
+SKIP_INTEGRATIONS = True
 
 
 def create_input(shape):
@@ -30,7 +30,7 @@ def fastmri_mock_dataset(tmp_path_factory):
 
 @pytest.fixture
 def skip_integration_tests():
-    return skip_integrations
+    return SKIP_INTEGRATIONS
 
 
 @pytest.fixture

--- a/tests/create_temp_data.py
+++ b/tests/create_temp_data.py
@@ -1,0 +1,106 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import h5py
+import numpy as np
+
+
+def create_temp_data(path):
+    rg = np.random.default_rng(seed=1234)
+    max_num_slices = 15
+    max_num_coils = 15
+    data_splits = {
+        "knee_data": [
+            "multicoil_train",
+            "multicoil_val",
+            "multicoil_test",
+            "multicoil_challenge",
+            "singlecoil_train",
+            "singlecoil_val",
+            "singlecoil_test",
+            "singlecoil_challenge",
+        ],
+        "brain_data": [
+            "multicoil_train",
+            "multicoil_val",
+            "multicoil_test",
+            "multicoil_challenge",
+        ],
+    }
+
+    enc_sizes = {
+        "train": [(1, 128, 64), (1, 128, 49), (1, 150, 67)],
+        "val": [(1, 128, 64), (1, 170, 57)],
+        "test": [(1, 128, 64), (1, 96, 96)],
+        "challenge": [(1, 128, 64), (1, 96, 48)],
+    }
+    recon_sizes = {
+        "train": [(1, 64, 64), (1, 49, 49), (1, 67, 67)],
+        "val": [(1, 64, 64), (1, 57, 47)],
+        "test": [(1, 64, 64), (1, 96, 96)],
+        "challenge": [(1, 64, 64), (1, 48, 48)],
+    }
+
+    metadata = {}
+    for dataset in data_splits:
+        for split in data_splits[dataset]:
+            fcount = 0
+            (path / dataset / split).mkdir(parents=True)
+            encs = enc_sizes[split.split("_")[-1]]
+            recs = recon_sizes[split.split("_")[-1]]
+            for i in range(len(encs)):
+                fname = path / dataset / split / f"file{fcount}.h5"
+                num_slices = rg.integers(2, max_num_slices)
+                if "multicoil" in split:
+                    num_coils = rg.integers(2, max_num_coils)
+                    enc_size = (num_slices, num_coils, encs[i][-2], encs[i][-1])
+                    recon_size = (num_slices, recs[i][-2], recs[i][-1])
+                else:
+                    enc_size = (num_slices, encs[i][-2], encs[i][-1])
+                    recon_size = (num_slices, recs[i][-2], recs[i][-1])
+
+                data = rg.normal(size=enc_size) + 1j * rg.normal(size=enc_size)
+
+                if split.split("_")[-1] in ("train", "val"):
+                    recon = np.absolute(rg.normal(size=recon_size)).astype(
+                        np.dtype("<f4")
+                    )
+                else:
+                    mask = rg.integers(0, 2, size=recon_size[-1]).astype(np.bool)
+
+                with h5py.File(fname, "w") as hf:
+                    hf.create_dataset("kspace", data=data.astype(np.complex64))
+                    if split.split("_")[-1] in ("train", "val"):
+                        hf.attrs["max"] = recon.max()
+                        if "singlecoil" in split:
+                            hf.create_dataset("reconstruction_esc", data=recon)
+                        else:
+                            hf.create_dataset("reconstruction_rss", data=recon)
+                    else:
+                        hf.create_dataset("mask", data=mask)
+
+                enc_size = encs[i]
+
+                enc_limits_center = enc_size[1] // 2 + 1
+                enc_limits_max = enc_size[1] - 2
+
+                padding_left = enc_size[1] // 2 - enc_limits_center
+                padding_right = padding_left + enc_limits_max
+
+                metadata[str(fname)] = (
+                    {
+                        "padding_left": padding_left,
+                        "padding_right": padding_right,
+                        "encoding_size": enc_size,
+                        "recon_size": recon_size,
+                    },
+                    num_slices,
+                )
+
+                fcount += 1
+
+    return path / "knee_data", path / "brain_data", metadata

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,50 +5,80 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-import pytest
-from fastmri.data.mri_data import CombinedSliceDataset, SliceDataset, fetch_dir
+from fastmri.data.mri_data import SliceDataset, CombinedSliceDataset
 
 
-def test_knee_dataset_lengths(knee_split_lens, skip_data_test):
-    if skip_data_test:
-        pytest.skip("config set to skip")
+def test_slice_datasets(fastmri_mock_dataset, monkeypatch):
+    knee_path, brain_path, metadata = fastmri_mock_dataset
 
-    knee_path = fetch_dir("knee_path")
+    def retrieve_metadata_mock(a, fname):
+        return metadata[str(fname)]
 
-    for split, data_len in knee_split_lens.items():
-        challenge = "multicoil" if "multicoil" in split else "singlecoil"
-        dataset = SliceDataset(knee_path / split, transform=None, challenge=challenge)
+    monkeypatch.setattr(SliceDataset, "_retrieve_metadata", retrieve_metadata_mock)
 
-        assert len(dataset) == data_len
-
-
-def test_brain_dataset_lengths(brain_split_lens, skip_data_test):
-    if skip_data_test:
-        pytest.skip("config set to skip")
-
-    brain_path = fetch_dir("brain_path")
-
-    for split, data_len in brain_split_lens.items():
-        dataset = SliceDataset(
-            brain_path / split, transform=None, challenge="multicoil"
-        )
-
-        assert len(dataset) == data_len
-
-
-def test_combined_dataset_lengths(knee_split_lens, brain_split_lens, skip_data_test):
-    if skip_data_test:
-        pytest.skip("config set to skip")
-
-    knee_path = fetch_dir("knee_path")
-    brain_path = fetch_dir("brain_path")
-
-    for knee_split, knee_data_len in knee_split_lens.items():
-        for brain_split, brain_data_len in brain_split_lens.items():
-            dataset = CombinedSliceDataset(
-                [knee_path / knee_split, brain_path / brain_split],
-                transforms=[None, None],
-                challenges=["multicoil", "multicoil"],
+    for challenge in ("multicoil", "singlecoil"):
+        for split in ("train", "val", "test", "challenge"):
+            dataset = SliceDataset(
+                knee_path / f"{challenge}_{split}", transform=None, challenge=challenge
             )
 
-            assert len(dataset) == knee_data_len + brain_data_len
+            assert len(dataset) > 0
+
+            item = dataset[0]
+            assert item is not None
+
+    for challenge in ("multicoil",):
+        for split in ("train", "val", "test", "challenge"):
+            dataset = SliceDataset(
+                brain_path / f"{challenge}_{split}", transform=None, challenge=challenge
+            )
+
+            assert len(dataset) > 0
+
+            assert dataset[0] is not None
+            assert dataset[-1] is not None
+
+
+def test_combined_slice_dataset(fastmri_mock_dataset, monkeypatch):
+    knee_path, brain_path, metadata = fastmri_mock_dataset
+
+    def retrieve_metadata_mock(a, fname):
+        return metadata[str(fname)]
+
+    monkeypatch.setattr(SliceDataset, "_retrieve_metadata", retrieve_metadata_mock)
+
+    roots = [knee_path / "multicoil_train", knee_path / "multicoil_val"]
+    challenges = ["multicoil", "multicoil"]
+    transforms = [None, None]
+
+    dataset1 = SliceDataset(
+        root=roots[0], challenge=challenges[0], transform=transforms[0]
+    )
+    dataset2 = SliceDataset(
+        root=roots[1], challenge=challenges[1], transform=transforms[1]
+    )
+    comb_dataset = CombinedSliceDataset(
+        roots=roots, challenges=challenges, transforms=transforms
+    )
+
+    assert len(comb_dataset) == len(dataset1) + len(dataset2)
+    assert comb_dataset[0] is not None
+    assert comb_dataset[-1] is not None
+
+    roots = [brain_path / "multicoil_train", brain_path / "multicoil_val"]
+    challenges = ["multicoil", "multicoil"]
+    transforms = [None, None]
+
+    dataset1 = SliceDataset(
+        root=roots[0], challenge=challenges[0], transform=transforms[0]
+    )
+    dataset2 = SliceDataset(
+        root=roots[1], challenge=challenges[1], transform=transforms[1]
+    )
+    comb_dataset = CombinedSliceDataset(
+        roots=roots, challenges=challenges, transforms=transforms
+    )
+
+    assert len(comb_dataset) == len(dataset1) + len(dataset2)
+    assert comb_dataset[0] is not None
+    assert comb_dataset[-1] is not None

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,56 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import pytest
+from fastmri.data.mri_data import CombinedSliceDataset, SliceDataset, fetch_dir
+
+
+def test_knee_dataset_lengths(knee_split_lens, skip_integration_tests):
+    if skip_integration_tests:
+        pytest.skip("config set to skip")
+
+    knee_path = fetch_dir("knee_path")
+
+    for split, data_len in knee_split_lens.items():
+        challenge = "multicoil" if "multicoil" in split else "singlecoil"
+        dataset = SliceDataset(knee_path / split, transform=None, challenge=challenge)
+
+        assert len(dataset) == data_len
+
+
+def test_brain_dataset_lengths(brain_split_lens, skip_integration_tests):
+    if skip_integration_tests:
+        pytest.skip("config set to skip")
+
+    brain_path = fetch_dir("brain_path")
+
+    for split, data_len in brain_split_lens.items():
+        dataset = SliceDataset(
+            brain_path / split, transform=None, challenge="multicoil"
+        )
+
+        assert len(dataset) == data_len
+
+
+def test_combined_dataset_lengths(
+    knee_split_lens, brain_split_lens, skip_integration_tests
+):
+    if skip_integration_tests:
+        pytest.skip("config set to skip")
+
+    knee_path = fetch_dir("knee_path")
+    brain_path = fetch_dir("brain_path")
+
+    for knee_split, knee_data_len in knee_split_lens.items():
+        for brain_split, brain_data_len in brain_split_lens.items():
+            dataset = CombinedSliceDataset(
+                [knee_path / knee_split, brain_path / brain_split],
+                transforms=[None, None],
+                challenges=["multicoil", "multicoil"],
+            )
+
+            assert len(dataset) == knee_data_len + brain_data_len


### PR DESCRIPTION
This adds dataset mocking so that we can keep track of our data loaders and PyTorch Lightning modules in CircleCI. This is part of our ongoing initiative to get the repo to longterm stability (Issue #84) It creates a little mock dataset and reads from it.

Dealing with the ISMRMRD header is a little more funky so I decided to just `monkeypatch` it.

The dataset tests evaluate the three main data set functions: `__init__`, `__len__`, and `__getitem__`. They don't validate the content of the mocked data.

The module tests use the data splits to run one step each of `train`, `val`, and `test`.