### PR TITLE
Add ffts for PyTorch 1.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             pip install dist/*.whl
       - run:
           command: |
-            echo "PyTorch \c" && pip show torch | grep Version 
+            echo -e "PyTorch \c" && pip show torch | grep Version 
             pytest --version
             pytest tests
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             pip install dist/*.whl
       - run:
           command: |
+            pip show torch | grep Version
             pytest --version
             pytest tests
             mypy fastmri

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,16 +13,19 @@ jobs:
           pip-dependency-file: dev-requirements.txt
           pkg-manager: pip
       - run:
+          command: |
+            mypy fastmri
+          name: Check Typing
+      - run:
           name: Install fastMRI
           command: |
             python setup.py bdist_wheel
             pip install dist/*.whl
       - run:
           command: |
-            pip show torch | grep Version
+            echo "PyTorch \c" && pip show torch | grep Version 
             pytest --version
             pytest tests
-            mypy fastmri
           name: Test
 
 workflows:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ add_header.py
 *fair_cluster*
 fastmri_dirs.yaml
 dataset_cache.pkl
+.mypy_cache/

--- a/fastmri/math.py
+++ b/fastmri/math.py
@@ -79,7 +79,9 @@ def fft2c(data: torch.Tensor) -> torch.Tensor:
     data = ifftshift(data, dim=(-3, -2))
     if USE_COMPLEX_FFT:
         data = torch.view_as_real(
-            torch.fft.fftn(torch.view_as_complex(data), dim=(-2, -1), norm="ortho")
+            torch.fft.fftn(  # type: ignore
+                torch.view_as_complex(data), dim=(-2, -1), norm="ortho"
+            )
         )
     else:
         data = torch.fft(data, 2, normalized=True)
@@ -106,7 +108,9 @@ def ifft2c(data: torch.Tensor) -> torch.Tensor:
     data = ifftshift(data, dim=(-3, -2))
     if USE_COMPLEX_FFT:
         data = torch.view_as_real(
-            torch.fft.ifftn(torch.view_as_complex(data), dim=(-2, -1), norm="ortho")
+            torch.fft.ifftn(  # type: ignore
+                torch.view_as_complex(data), dim=(-2, -1), norm="ortho"
+            )
         )
     else:
         data = torch.ifft(data, 2, normalized=True)

--- a/fastmri/math.py
+++ b/fastmri/math.py
@@ -13,7 +13,7 @@ from packaging import version
 
 if version.parse(torch.__version__) >= version.parse("1.6.0"):
     USE_COMPLEX_FFT = True
-    import torch.fft
+    import torch.fft  # type: ignore
 else:
     USE_COMPLEX_FFT = False
 

--- a/fastmri/math.py
+++ b/fastmri/math.py
@@ -11,7 +11,7 @@ import numpy as np
 import torch
 from packaging import version
 
-if version.parse(torch.__version__) >= version.parse("1.6.0"):
+if version.parse(torch.__version__) >= version.parse("1.7.0"):
     USE_COMPLEX_FFT = True
     import torch.fft  # type: ignore
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.18.5
 scikit_image>=0.16.2
 torchvision>=0.6.0
-torch==1.6
+torch>=1.6
 runstats>=1.8.0
 pytorch_lightning>=1.0.0
 h5py>=2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.18.5
 scikit_image>=0.16.2
 torchvision>=0.6.0
-torch>=1.6
+torch==1.6
 runstats>=1.8.0
 pytorch_lightning>=1.0.0
 h5py>=2.10.0


### PR DESCRIPTION
This future-proofs us (Issue #84) for PyTorch 1.7 FFT functions. A version check is applied to make sure the import is handled properly.