### PR TITLE
Make models scriptable

### DIFF
--- a/fastmri/__init__.py
+++ b/fastmri/__init__.py
@@ -4,19 +4,24 @@ Copyright (c) Facebook, Inc. and its affiliates.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
+import torch
+from packaging import version
 
 from .coil_combine import rss, rss_complex
+from .fftc import fftshift, ifftshift, roll
 from .losses import SSIMLoss
 from .math import (
     complex_abs,
     complex_abs_sq,
     complex_conj,
     complex_mul,
-    fft2c,
-    fftshift,
-    ifft2c,
-    ifftshift,
-    roll,
     tensor_to_complex_np,
 )
 from .utils import save_reconstructions
+
+if version.parse(torch.__version__) >= version.parse("1.7.0"):
+    from .fftc import fft2c_new as fft2c
+    from .fftc import ifft2c_new as ifft2c
+else:
+    from .fftc import fft2c_old as fft2c
+    from .fftc import ifft2c_old as ifft2c

--- a/fastmri/fftc.py
+++ b/fastmri/fftc.py
@@ -1,0 +1,203 @@
+from typing import List, Optional
+
+import torch
+from packaging import version
+
+if version.parse(torch.__version__) >= version.parse("1.7.0"):
+    import torch.fft  # type: ignore
+
+
+def fft2c_old(data: torch.Tensor) -> torch.Tensor:
+    """
+    Apply centered 2 dimensional Fast Fourier Transform.
+
+    Args:
+        data: Complex valued input data containing at least 3 dimensions:
+            dimensions -3 & -2 are spatial dimensions and dimension -1 has size
+            2. All other dimensions are assumed to be batch dimensions.
+
+    Returns:
+        The FFT of the input.
+    """
+    if not data.shape[-1] == 2:
+        raise ValueError("Tensor does not have separate complex dim.")
+
+    data = ifftshift(data, dim=[-3, -2])
+    data = torch.fft(data, 2, normalized=True)
+    data = fftshift(data, dim=[-3, -2])
+
+    return data
+
+
+def ifft2c_old(data: torch.Tensor) -> torch.Tensor:
+    """
+    Apply centered 2-dimensional Inverse Fast Fourier Transform.
+
+    Args:
+        data: Complex valued input data containing at least 3 dimensions:
+            dimensions -3 & -2 are spatial dimensions and dimension -1 has size
+            2. All other dimensions are assumed to be batch dimensions.
+
+    Returns:
+        The IFFT of the input.
+    """
+    if not data.shape[-1] == 2:
+        raise ValueError("Tensor does not have separate complex dim.")
+
+    data = ifftshift(data, dim=[-3, -2])
+    data = torch.ifft(data, 2, normalized=True)
+    data = fftshift(data, dim=[-3, -2])
+
+    return data
+
+
+def fft2c_new(data: torch.Tensor) -> torch.Tensor:
+    """
+    Apply centered 2 dimensional Fast Fourier Transform.
+
+    Args:
+        data: Complex valued input data containing at least 3 dimensions:
+            dimensions -3 & -2 are spatial dimensions and dimension -1 has size
+            2. All other dimensions are assumed to be batch dimensions.
+
+    Returns:
+        The FFT of the input.
+    """
+    if not data.shape[-1] == 2:
+        raise ValueError("Tensor does not have separate complex dim.")
+
+    data = ifftshift(data, dim=[-3, -2])
+    data = torch.view_as_real(
+        torch.fft.fftn(  # type: ignore
+            torch.view_as_complex(data), dim=(-2, -1), norm="ortho"
+        )
+    )
+    data = fftshift(data, dim=[-3, -2])
+
+    return data
+
+
+def ifft2c_new(data: torch.Tensor) -> torch.Tensor:
+    """
+    Apply centered 2-dimensional Inverse Fast Fourier Transform.
+
+    Args:
+        data: Complex valued input data containing at least 3 dimensions:
+            dimensions -3 & -2 are spatial dimensions and dimension -1 has size
+            2. All other dimensions are assumed to be batch dimensions.
+
+    Returns:
+        The IFFT of the input.
+    """
+    if not data.shape[-1] == 2:
+        raise ValueError("Tensor does not have separate complex dim.")
+
+    data = ifftshift(data, dim=[-3, -2])
+    data = torch.view_as_real(
+        torch.fft.ifftn(  # type: ignore
+            torch.view_as_complex(data), dim=(-2, -1), norm="ortho"
+        )
+    )
+    data = fftshift(data, dim=[-3, -2])
+
+    return data
+
+
+# Helper functions
+
+
+def roll_one_dim(x: torch.Tensor, shift: int, dim: int) -> torch.Tensor:
+    """
+    Similar to roll but for only one dim.
+
+    Args:
+        x: A PyTorch tensor.
+        shift: Amount to roll.
+        dim: Which dimension to roll.
+
+    Returns:
+        Rolled version of x.
+    """
+    shift = shift % x.size(dim)
+    if shift == 0:
+        return x
+
+    left = x.narrow(dim, 0, x.size(dim) - shift)
+    right = x.narrow(dim, x.size(dim) - shift, shift)
+
+    return torch.cat((right, left), dim=dim)
+
+
+def roll(
+    x: torch.Tensor,
+    shift: List[int],
+    dim: List[int],
+) -> torch.Tensor:
+    """
+    Similar to np.roll but applies to PyTorch Tensors.
+
+    Args:
+        x: A PyTorch tensor.
+        shift: Amount to roll.
+        dim: Which dimension to roll.
+
+    Returns:
+        Rolled version of x.
+    """
+    if len(shift) != len(dim):
+        raise ValueError("len(shift) must match len(dim)")
+
+    for (s, d) in zip(shift, dim):
+        x = roll_one_dim(x, s, d)
+
+    return x
+
+
+def fftshift(x: torch.Tensor, dim: Optional[List[int]] = None) -> torch.Tensor:
+    """
+    Similar to np.fft.fftshift but applies to PyTorch Tensors
+
+    Args:
+        x: A PyTorch tensor.
+        dim: Which dimension to fftshift.
+
+    Returns:
+        fftshifted version of x.
+    """
+    if dim is None:
+        # this weird code is necessary for toch.jit.script typing
+        dim = [0] * (x.dim())
+        for i in range(1, x.dim()):
+            dim[i] = i
+
+    # also necessary for torch.jit.script
+    shift = [0] * len(dim)
+    for i, dim_num in enumerate(dim):
+        shift[i] = x.shape[dim_num] // 2
+
+    return roll(x, shift, dim)
+
+
+def ifftshift(x: torch.Tensor, dim: Optional[List[int]] = None) -> torch.Tensor:
+    """
+    Similar to np.fft.ifftshift but applies to PyTorch Tensors
+
+    Args:
+        x: A PyTorch tensor.
+        dim: Which dimension to ifftshift.
+
+    Returns:
+        ifftshifted version of x.
+    """
+    if dim is None:
+        # this weird code is necessary for toch.jit.script typing
+        dim = [0] * (x.dim())
+        for i in range(1, x.dim()):
+            dim[i] = i
+
+    # also necessary for torch.jit.script
+    shift = [0] * len(dim)
+    for i, dim_num in enumerate(dim):
+        shift[i] = (x.shape[dim_num] + 1) // 2
+
+    return roll(x, shift, dim)

--- a/fastmri/fftc.py
+++ b/fastmri/fftc.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from typing import List, Optional
 
 import torch

--- a/fastmri/math.py
+++ b/fastmri/math.py
@@ -5,17 +5,9 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-from typing import List, Optional, Tuple, Union
-
 import numpy as np
 import torch
 from packaging import version
-
-if version.parse(torch.__version__) >= version.parse("1.7.0"):
-    USE_COMPLEX_FFT = True
-    import torch.fft  # type: ignore
-else:
-    USE_COMPLEX_FFT = False
 
 
 def complex_mul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -61,64 +53,6 @@ def complex_conj(x: torch.Tensor) -> torch.Tensor:
     return torch.stack((x[..., 0], -x[..., 1]), dim=-1)
 
 
-def fft2c(data: torch.Tensor) -> torch.Tensor:
-    """
-    Apply centered 2 dimensional Fast Fourier Transform.
-
-    Args:
-        data: Complex valued input data containing at least 3 dimensions:
-            dimensions -3 & -2 are spatial dimensions and dimension -1 has size
-            2. All other dimensions are assumed to be batch dimensions.
-
-    Returns:
-        The FFT of the input.
-    """
-    if not data.shape[-1] == 2:
-        raise ValueError("Tensor does not have separate complex dim.")
-
-    data = ifftshift(data, dim=(-3, -2))
-    if USE_COMPLEX_FFT:
-        data = torch.view_as_real(
-            torch.fft.fftn(  # type: ignore
-                torch.view_as_complex(data), dim=(-2, -1), norm="ortho"
-            )
-        )
-    else:
-        data = torch.fft(data, 2, normalized=True)
-    data = fftshift(data, dim=(-3, -2))
-
-    return data
-
-
-def ifft2c(data: torch.Tensor) -> torch.Tensor:
-    """
-    Apply centered 2-dimensional Inverse Fast Fourier Transform.
-
-    Args:
-        data: Complex valued input data containing at least 3 dimensions:
-            dimensions -3 & -2 are spatial dimensions and dimension -1 has size
-            2. All other dimensions are assumed to be batch dimensions.
-
-    Returns:
-        The IFFT of the input.
-    """
-    if not data.shape[-1] == 2:
-        raise ValueError("Tensor does not have separate complex dim.")
-
-    data = ifftshift(data, dim=(-3, -2))
-    if USE_COMPLEX_FFT:
-        data = torch.view_as_real(
-            torch.fft.ifftn(  # type: ignore
-                torch.view_as_complex(data), dim=(-2, -1), norm="ortho"
-            )
-        )
-    else:
-        data = torch.ifft(data, 2, normalized=True)
-    data = fftshift(data, dim=(-3, -2))
-
-    return data
-
-
 def complex_abs(data: torch.Tensor) -> torch.Tensor:
     """
     Compute the absolute value of a complex valued input tensor.
@@ -151,93 +85,6 @@ def complex_abs_sq(data: torch.Tensor) -> torch.Tensor:
         raise ValueError("Tensor does not have separate complex dim.")
 
     return (data ** 2).sum(dim=-1)
-
-
-# Helper functions
-
-
-def roll(
-    x: torch.Tensor,
-    shift: Union[int, Tuple[int, ...], List[int]],
-    dim: Union[int, Tuple[int, ...], List[int]],
-) -> torch.Tensor:
-    """
-    Similar to np.roll but applies to PyTorch Tensors.
-
-    Args:
-        x: A PyTorch tensor.
-        shift: Amount to roll.
-        dim: Which dimension to roll.
-
-    Returns:
-        Rolled version of x.
-    """
-    if isinstance(shift, (tuple, list)):
-        if not isinstance(dim, (tuple, list)):
-            raise ValueError("Passed Sequence for shift but not for dim.")
-        assert len(shift) == len(dim)
-        for s, d in zip(shift, dim):
-            x = roll(x, s, d)
-        return x
-    elif isinstance(dim, (tuple, list)):
-        raise ValueError("Passed Sequence for dim but not for shift.")
-
-    shift = shift % x.size(dim)
-    if shift == 0:
-        return x
-
-    left = x.narrow(dim, 0, x.size(dim) - shift)
-    right = x.narrow(dim, x.size(dim) - shift, shift)
-
-    return torch.cat((right, left), dim=dim)
-
-
-def fftshift(
-    x: torch.Tensor, dim: Optional[Union[Tuple[int, ...], List[int]]] = None
-) -> torch.Tensor:
-    """
-    Similar to np.fft.fftshift but applies to PyTorch Tensors
-
-    Args:
-        x: A PyTorch tensor.
-        dim: Which dimension to fftshift.
-
-    Returns:
-        fftshifted version of x.
-    """
-    if dim is None:
-        dim = tuple(range(x.dim()))
-        shift = [dim // 2 for dim in x.shape]
-    elif isinstance(dim, int):
-        shift = x.shape[dim] // 2
-    else:
-        shift = [x.shape[i] // 2 for i in dim]
-
-    return roll(x, shift, dim)
-
-
-def ifftshift(
-    x: torch.Tensor, dim: Optional[Union[Tuple[int, ...], List[int]]] = None
-) -> torch.Tensor:
-    """
-    Similar to np.fft.ifftshift but applies to PyTorch Tensors
-
-    Args:
-        x: A PyTorch tensor.
-        dim: Which dimension to ifftshift.
-
-    Returns:
-        ifftshifted version of x.
-    """
-    if dim is None:
-        dim = tuple(range(x.dim()))
-        shift = [(dim + 1) // 2 for dim in x.shape]
-    elif isinstance(dim, int):
-        shift = (x.shape[dim] + 1) // 2
-    else:
-        shift = [(x.shape[i] + 1) // 2 for i in dim]
-
-    return roll(x, shift, dim)
 
 
 def tensor_to_complex_np(data: torch.Tensor) -> np.ndarray:

--- a/fastmri/models/unet.py
+++ b/fastmri/models/unet.py
@@ -96,7 +96,7 @@ class Unet(nn.Module):
                 padding[1] = 1  # padding right
             if output.shape[-2] != downsample_layer.shape[-2]:
                 padding[3] = 1  # padding bottom
-            if sum(padding) != 0:
+            if torch.sum(torch.tensor(padding)) != 0:
                 output = F.pad(output, padding, "reflect")
 
             output = torch.cat([output, downsample_layer], dim=1)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -70,7 +70,13 @@ def test_root_sum_of_squares(shape, dim):
 @pytest.mark.parametrize("shape", [[5, 6, 2], [3, 4, 5],])
 def test_roll(shift, dim, shape):
     x = np.arange(np.product(shape)).reshape(shape)
-    out_torch = fastmri.roll(torch.from_numpy(x), shift, dim).numpy()
+    if isinstance(shift, int) and isinstance(dim, int):
+        torch_shift = (shift,)
+        torch_dim = (dim,)
+    else:
+        torch_shift = shift
+        torch_dim = dim
+    out_torch = fastmri.roll(torch.from_numpy(x), torch_shift, torch_dim).numpy()
     out_numpy = np.roll(x, shift, dim)
 
     assert np.allclose(out_torch, out_numpy)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,7 @@ LICENSE file in the root directory of this source tree.
 """
 
 import pytest
+import torch
 from fastmri.data import transforms
 from fastmri.data.subsample import RandomMaskFunc
 from fastmri.models import Unet, VarNet
@@ -53,3 +54,27 @@ def test_varnet(shape, out_chans, chans, center_fractions, accelerations):
     y = varnet(output, mask.byte())
 
     assert y.shape[1:] == x.shape[2:4]
+
+
+def test_unet_scripting():
+    model = Unet(
+        in_chans=1,
+        out_chans=1,
+        chans=8,
+        num_pool_layers=2,
+        drop_prob=0.0,
+    )
+    scr = torch.jit.script(model)
+    assert scr is not None
+
+
+def test_varnet_scripting():
+    model = VarNet(
+        num_cascades=4,
+        pools=2,
+        chans=8,
+        sens_pools=2,
+        sens_chans=4,
+    )
+    scr = torch.jit.script(model)
+    assert scr is not None

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -8,7 +8,6 @@ LICENSE file in the root directory of this source tree.
 from argparse import ArgumentParser
 
 import pytest
-import torch
 from fastmri.data import SliceDataset
 from fastmri.data.subsample import create_mask_for_mask_type
 from fastmri.data.transforms import UnetDataTransform, VarNetDataTransform
@@ -245,35 +244,3 @@ def test_varnet_trainer(fastmri_mock_dataset, backend, tmp_path, monkeypatch):
     trainer = Trainer.from_argparse_args(params)
 
     trainer.fit(model, data_module)
-
-
-def test_unet_scripting():
-    model = UnetModule(
-        in_chans=1,
-        out_chans=1,
-        chans=8,
-        num_pool_layers=2,
-        drop_prob=0.0,
-        lr=0.001,
-        lr_step_size=40,
-        lr_gamma=0.1,
-        weight_decay=0.0,
-    )
-    scr = torch.jit.script(model.unet)
-    assert scr is not None
-
-
-def test_varnet_scripting():
-    model = VarNetModule(
-        num_cascades=4,
-        pools=2,
-        chans=8,
-        sens_pools=2,
-        sens_chans=4,
-        lr=0.001,
-        lr_step_size=40,
-        lr_gamma=0.1,
-        weight_decay=0.0,
-    )
-    scr = torch.jit.script(model.varnet)
-    assert scr is not None

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 from argparse import ArgumentParser
 
 import pytest
+import torch
 from fastmri.data import SliceDataset
 from fastmri.data.subsample import create_mask_for_mask_type
 from fastmri.data.transforms import UnetDataTransform, VarNetDataTransform
@@ -244,3 +245,35 @@ def test_varnet_trainer(fastmri_mock_dataset, backend, tmp_path, monkeypatch):
     trainer = Trainer.from_argparse_args(params)
 
     trainer.fit(model, data_module)
+
+
+def test_unet_scripting():
+    model = UnetModule(
+        in_chans=1,
+        out_chans=1,
+        chans=8,
+        num_pool_layers=2,
+        drop_prob=0.0,
+        lr=0.001,
+        lr_step_size=40,
+        lr_gamma=0.1,
+        weight_decay=0.0,
+    )
+    scr = torch.jit.script(model.unet)
+    assert scr is not None
+
+
+def test_varnet_scripting():
+    model = VarNetModule(
+        num_cascades=4,
+        pools=2,
+        chans=8,
+        sens_pools=2,
+        sens_chans=4,
+        lr=0.001,
+        lr_step_size=40,
+        lr_gamma=0.1,
+        weight_decay=0.0,
+    )
+    scr = torch.jit.script(model.varnet)
+    assert scr is not None


### PR DESCRIPTION
This PR makes the U-Net and VarNet models scriptable, an item in Issue #84.

`torch.jit.script` really punishes use of high-level Python functions. To get this to work I had to modify a number of areas in the code base so that the compiler would work - reasons for modifications include type recognition, unsupported functions, use of globals, etc.

For the future I've also added a `torch.jit.script` test to make sure that any changes we make won't break this new feature.