### PR TITLE
Fix to the issues of running unit tests and 

### DIFF
--- a/fastmri/data/subsample.py
+++ b/fastmri/data/subsample.py
@@ -53,7 +53,7 @@ class MaskFunc:
 
         self.center_fractions = center_fractions
         self.accelerations = accelerations
-        self.rng = np.random
+        self.rng = np.random.RandomState()
 
     def __call__(
         self, shape: Sequence[int], seed: Optional[Union[int, Tuple[int, ...]]] = None


### PR DESCRIPTION
Change is to use RandomState(). Without it, there's the error received that a module object can't be pickled. The error is in reproducible in Windows 10 and OS X Catalina.