### PR TITLE
Fix monitor

### DIFF
--- a/fastmri_examples/unet/train_unet_demo.py
+++ b/fastmri_examples/unet/train_unet_demo.py
@@ -162,7 +162,7 @@ def build_args():
         filepath=args.default_root_dir / "checkpoints",
         save_top_k=True,
         verbose=True,
-        monitor="val_loss",
+        monitor="validation_loss",
         mode="min",
         prefix="",
     )

--- a/fastmri_examples/varnet/train_varnet_demo.py
+++ b/fastmri_examples/varnet/train_varnet_demo.py
@@ -168,7 +168,7 @@ def build_args():
         filepath=args.default_root_dir / "checkpoints",
         save_top_k=True,
         verbose=True,
-        monitor="val_loss",
+        monitor="validation_loss",
         mode="min",
         prefix="",
     )


### PR DESCRIPTION
This fixes the monitor for `ModelCheckpoint` in the demo scripts as identified in Issue #108. Previously it was set to `val_loss`, which has been renamed due to a [Pytorch Lightning issue](https://github.com/PyTorchLightning/pytorch-lightning/issues/4553).

I've tested this update past one epoch and it logs checkpoints as expected.