### PR TITLE
VolumeSampler fix

### DIFF
--- a/fastmri/data/volume_sampler.py
+++ b/fastmri/data/volume_sampler.py
@@ -100,6 +100,8 @@ class VolumeSampler(Sampler):
             indices = self.indices
 
         # add extra samples to match num_samples
+        repeat_times = self.num_samples // len(indices)
+        indices = indices * repeat_times
         indices = indices + indices[: self.num_samples - len(indices)]
         assert len(indices) == self.num_samples
 


### PR DESCRIPTION
Currently VolumeSampler crashes if the number of unique slices assigned to a certain GPU is less than half of `num_samples`. This can happen if the number of slices across volumes in a dataset varies a lot. To fix this issue we can repeat all assigned indices to close the gap before exactly matching `num_samples`.