### PR TITLE
Fix all versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 wheel
-pytest
-mypy==0.790
+pytest==5.4.3
+mypy==0.800
 black==20.8b1
-flake8
+flake8==3.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy>=1.18.5
-scikit_image>=0.16.2
-torchvision>=0.6.0
-torch>=1.7
-runstats>=1.8.0
-pytorch_lightning>=1.0.0
-h5py>=2.10.0
-PyYAML>=5.3.1
+numpy==1.18.5
+scikit_image==0.16.2
+torchvision==0.8.1
+torch==1.7.1
+runstats==1.8.0
+pytorch_lightning==1.0.6
+h5py==2.10.0
+PyYAML==5.3.1


### PR DESCRIPTION
Fixes `mypy` failures in PR #119 by fixing versions in `requirements.txt` and `dev-requirements.txt`. We should have fixed these to begin with to prevent test flakiness.