### PR TITLE
validation ssim fix

### DIFF
--- a/fastmri/evaluate.py
+++ b/fastmri/evaluate.py
@@ -37,6 +37,11 @@ def ssim(
     gt: np.ndarray, pred: np.ndarray, maxval: Optional[float] = None
 ) -> np.ndarray:
     """Compute Structural Similarity Index Metric (SSIM)"""
+    if not gt.ndim == 3:
+        raise ValueError("Unexpected number of dimensions in ground truth.")
+    if not gt.ndim == pred.ndim:
+        raise ValueError("Ground truth dimensions does not match pred.")
+
     maxval = gt.max() if maxval is None else maxval
 
     ssim = 0

--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -136,7 +136,7 @@ class MriModule(pl.LightningModule):
                 evaluate.nmse(target, output)
             ).view(1)
             ssim_vals[fname][slice_num] = torch.tensor(
-                evaluate.ssim(target, output, maxval=maxval)
+                evaluate.ssim(target[None, ...], output[None, ...], maxval=maxval)
             ).view(1)
             psnr_vals[fname][slice_num] = torch.tensor(
                 evaluate.psnr(target, output)


### PR DESCRIPTION
`evaluate.ssim` receives a 2D array when a 3D array is expected with a slice dimension first. This results in wrong validation SSIM, which is fixed by adding a singleton dimension to the recons and targets.

Maybe a dimension check in `evaluate.ssim` would help avoiding this bug later?