### PR TITLE
Fix NMSE and PSNR aggregation in validation loop

### DIFF
--- a/fastmri/evaluate.py
+++ b/fastmri/evaluate.py
@@ -28,7 +28,9 @@ def nmse(gt: np.ndarray, pred: np.ndarray) -> np.ndarray:
     return np.linalg.norm(gt - pred) ** 2 / np.linalg.norm(gt) ** 2
 
 
-def psnr(gt: np.ndarray, pred: np.ndarray, maxval: Optional[float] = None) -> np.ndarray:
+def psnr(
+    gt: np.ndarray, pred: np.ndarray, maxval: Optional[float] = None
+) -> np.ndarray:
     """Compute Peak Signal to Noise Ratio metric (PSNR)"""
     if maxval is None:
         maxval = gt.max()

--- a/fastmri/evaluate.py
+++ b/fastmri/evaluate.py
@@ -28,9 +28,11 @@ def nmse(gt: np.ndarray, pred: np.ndarray) -> np.ndarray:
     return np.linalg.norm(gt - pred) ** 2 / np.linalg.norm(gt) ** 2
 
 
-def psnr(gt: np.ndarray, pred: np.ndarray) -> np.ndarray:
+def psnr(gt: np.ndarray, pred: np.ndarray, maxval: Optional[float] = None) -> np.ndarray:
     """Compute Peak Signal to Noise Ratio metric (PSNR)"""
-    return peak_signal_noise_ratio(gt, pred, data_range=gt.max())
+    if maxval is None:
+        maxval = gt.max()
+    return peak_signal_noise_ratio(gt, pred, data_range=maxval)
 
 
 def ssim(

--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -193,11 +193,16 @@ class MriModule(pl.LightningModule):
                 torch.cat([v.view(-1) for _, v in target_norms[fname].items()])
             )
             metrics["nmse"] = metrics["nmse"] + mse_val / target_norm
-            metrics["psnr"] = metrics["psnr"] + 20 * torch.log10(
-                torch.tensor(
-                    max_vals[fname], dtype=mse_val.dtype, device=mse_val.device
+            metrics["psnr"] = (
+                metrics["psnr"]
+                + 20
+                * torch.log10(
+                    torch.tensor(
+                        max_vals[fname], dtype=mse_val.dtype, device=mse_val.device
+                    )
                 )
-            ) - 10 * torch.log10(mse_val)
+                - 10 * torch.log10(mse_val)
+            )
             metrics["ssim"] = metrics["ssim"] + torch.mean(
                 torch.cat([v.view(-1) for _, v in ssim_vals[fname].items()])
             )

--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -123,66 +123,83 @@ class MriModule(pl.LightningModule):
                 )
 
         # compute evaluation metrics
-        nmse_vals = defaultdict(dict)
+        mse_vals = defaultdict(dict)
+        target_norms = defaultdict(dict)
         ssim_vals = defaultdict(dict)
-        psnr_vals = defaultdict(dict)
+        max_vals = dict()
         for i, fname in enumerate(val_logs["fname"]):
             slice_num = int(val_logs["slice_num"][i].cpu())
             maxval = val_logs["max_value"][i].cpu().numpy()
             output = val_logs["output"][i].cpu().numpy()
             target = val_logs["target"][i].cpu().numpy()
 
-            nmse_vals[fname][slice_num] = torch.tensor(
-                evaluate.nmse(target, output)
+            mse_vals[fname][slice_num] = torch.tensor(
+                evaluate.mse(target, output)
+            ).view(1)
+            target_norms[fname][slice_num] = torch.tensor(
+                evaluate.mse(target, np.zeros_like(target))
             ).view(1)
             ssim_vals[fname][slice_num] = torch.tensor(
                 evaluate.ssim(target[None, ...], output[None, ...], maxval=maxval)
             ).view(1)
-            psnr_vals[fname][slice_num] = torch.tensor(
-                evaluate.psnr(target, output)
-            ).view(1)
+            max_vals[fname] = maxval
 
         return {
             "val_loss": val_logs["val_loss"],
-            "nmse_vals": nmse_vals,
+            "mse_vals": mse_vals,
+            "target_norms": target_norms,
             "ssim_vals": ssim_vals,
-            "psnr_vals": psnr_vals,
+            "max_vals": max_vals,
         }
 
     def validation_epoch_end(self, val_logs):
         # aggregate losses
         losses = []
-        nmse_vals = defaultdict(dict)
+        mse_vals = defaultdict(dict)
+        target_norms = defaultdict(dict)
         ssim_vals = defaultdict(dict)
-        psnr_vals = defaultdict(dict)
+        max_vals = dict()
 
         # use dict updates to handle duplicate slices
         for val_log in val_logs:
             losses.append(val_log["val_loss"].view(-1))
 
-            for k in val_log["nmse_vals"].keys():
-                nmse_vals[k].update(val_log["nmse_vals"][k])
+            for k in val_log["mse_vals"].keys():
+                mse_vals[k].update(val_log["mse_vals"][k])
+            for k in val_log["target_norms"].keys():
+                target_norms[k].update(val_log["target_norms"][k])
             for k in val_log["ssim_vals"].keys():
                 ssim_vals[k].update(val_log["ssim_vals"][k])
-            for k in val_log["psnr_vals"].keys():
-                psnr_vals[k].update(val_log["psnr_vals"][k])
+            for k in val_log["max_vals"]:
+                max_vals[k] = val_log["max_vals"][k]
 
         # check to make sure we have all files in all metrics
-        assert nmse_vals.keys() == ssim_vals.keys() == psnr_vals.keys()
+        assert (
+            mse_vals.keys()
+            == target_norms.keys()
+            == ssim_vals.keys()
+            == max_vals.keys()
+        )
 
         # apply means across image volumes
         metrics = {"nmse": 0, "ssim": 0, "psnr": 0}
         local_examples = 0
-        for fname in nmse_vals.keys():
+        for fname in mse_vals.keys():
             local_examples = local_examples + 1
-            metrics["nmse"] = metrics["nmse"] + torch.mean(
-                torch.cat([v.view(-1) for _, v in nmse_vals[fname].items()])
+            mse_val = torch.mean(
+                torch.cat([v.view(-1) for _, v in mse_vals[fname].items()])
             )
+            target_norm = torch.mean(
+                torch.cat([v.view(-1) for _, v in target_norms[fname].items()])
+            )
+            metrics["nmse"] = metrics["nmse"] + mse_val / target_norm
+            metrics["psnr"] = metrics["psnr"] + 20 * torch.log10(
+                torch.tensor(
+                    max_vals[fname], dtype=mse_val.dtype, device=mse_val.device
+                )
+            ) - 10 * torch.log10(mse_val)
             metrics["ssim"] = metrics["ssim"] + torch.mean(
                 torch.cat([v.view(-1) for _, v in ssim_vals[fname].items()])
-            )
-            metrics["psnr"] = metrics["psnr"] + torch.mean(
-                torch.cat([v.view(-1) for _, v in psnr_vals[fname].items()])
             )
 
         # reduce across ddp via sum


### PR DESCRIPTION
This fixes metric aggregation for NMSE and PSNR in the validation loop of the Lightning modules, which likely caused Issue #129. Previously, NMSE was being normalized with the slice norm and PSNR was using the maximum value of the slice. Both of these should have been using volume metrics to match the methodology in the fastMRI paper. This PR fixes the volume metrics.

**Previous U-Net Knee Single-Coil**
NMSE: 0.04213
PSNR: 27.02

**This PR (epoch 43)**
NMSE: 0.0323
PSNR: 32.34