### PR TITLE
Make image logging more flexible

### DIFF
--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -71,13 +71,13 @@ class MriModule(pl.LightningModule):
     def validation_step_end(self, val_logs):
         # check inputs
         for k in (
-                "batch_idx",
-                "fname",
-                "slice_num",
-                "max_value",
-                "output",
-                "target",
-                "val_loss",
+            "batch_idx",
+            "fname",
+            "slice_num",
+            "max_value",
+            "output",
+            "target",
+            "val_loss",
         ):
             if k not in val_logs.keys():
                 raise RuntimeError(
@@ -96,7 +96,7 @@ class MriModule(pl.LightningModule):
         if self.val_log_indices is None:
             self.val_log_indices = list(
                 np.random.permutation(len(self.trainer.val_dataloaders[0]))[
-                : self.num_log_images
+                    : self.num_log_images
                 ]
             )
 
@@ -114,19 +114,9 @@ class MriModule(pl.LightningModule):
                 output = output / output.max()
                 target = target / target.max()
                 error = error / error.max()
-                experiments = self.logger.experiment if isinstance(self.logger.experiment, list) \
-                    else [self.logger.experiment]
-                for experiment in experiments:
-                    if isinstance(experiment, SummaryWriter):
-                        experiment.add_image(
-                            f"{key}/target", target, global_step=self.global_step
-                        )
-                        experiment.add_image(
-                            f"{key}/reconstruction", output, global_step=self.global_step
-                        )
-                        experiment.add_image(
-                            f"{key}/error", error, global_step=self.global_step
-                        )
+                self.log_image(f"{key}/target", target)
+                self.log_image(f"{key}/reconstruction", output)
+                self.log_image(f"{key}/error", error)
 
         # compute evaluation metrics
         mse_vals = defaultdict(dict)
@@ -158,6 +148,9 @@ class MriModule(pl.LightningModule):
             "max_vals": max_vals,
         }
 
+    def log_image(self, name, image):
+        self.logger.experiment.add_image(name, image, global_step=self.global_step)
+
     def validation_epoch_end(self, val_logs):
         # aggregate losses
         losses = []
@@ -181,10 +174,10 @@ class MriModule(pl.LightningModule):
 
         # check to make sure we have all files in all metrics
         assert (
-                mse_vals.keys()
-                == target_norms.keys()
-                == ssim_vals.keys()
-                == max_vals.keys()
+            mse_vals.keys()
+            == target_norms.keys()
+            == ssim_vals.keys()
+            == max_vals.keys()
         )
 
         # apply means across image volumes
@@ -200,14 +193,14 @@ class MriModule(pl.LightningModule):
             )
             metrics["nmse"] = metrics["nmse"] + mse_val / target_norm
             metrics["psnr"] = (
-                    metrics["psnr"]
-                    + 20
-                    * torch.log10(
-                torch.tensor(
-                    max_vals[fname], dtype=mse_val.dtype, device=mse_val.device
+                metrics["psnr"]
+                + 20
+                * torch.log10(
+                    torch.tensor(
+                        max_vals[fname], dtype=mse_val.dtype, device=mse_val.device
+                    )
                 )
-            )
-                    - 10 * torch.log10(mse_val)
+                - 10 * torch.log10(mse_val)
             )
             metrics["ssim"] = metrics["ssim"] + torch.mean(
                 torch.cat([v.view(-1) for _, v in ssim_vals[fname].items()])

--- a/fastmri/pl_modules/mri_module.py
+++ b/fastmri/pl_modules/mri_module.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 import numpy as np
 import pytorch_lightning as pl
 import torch
-from torch.utils.tensorboard import SummaryWriter
 
 import fastmri
 from fastmri import evaluate


### PR DESCRIPTION
The present code to log images during training assumes that there is a single Lightning logger in place, and that it is a `TensorboardLogger`. This PR changes that to allow for multiple loggers, and logs images only to those that are Tensorboard `SummaryWriters`.