### PR TITLE
[WIP] Fix out_path argument and describe TOOLPATH pointing location

### DIFF
--- a/fastmri_examples/cs/README.md
+++ b/fastmri_examples/cs/README.md
@@ -27,7 +27,7 @@ To run the reconstruction algorithm on the validation data, run:
 python run_bart.py \
     --challenge CHALLENGE \
     --data_path DATA \
-    --out_path reconstructions_val \
+    --output_path reconstructions_val \
     --reg_wt 0.01 \
     --mask_type MASK_TYPE \
     --split val
@@ -50,7 +50,7 @@ To apply the reconstruction algorithm to the test data, run:
 python run_bart.py \
     --challenge CHALLENGE \
     --data_path DATA \
-    --out_path reconstructions_test \
+    --output_path reconstructions_test \
     --split test
 ```
 

--- a/fastmri_examples/cs/README.md
+++ b/fastmri_examples/cs/README.md
@@ -12,13 +12,14 @@ which was used as a baseline model in
 The implementation uses the BART toolkit. To install BART, please follow the
 [installation instructions][bartlink].
 
-Once BART is installed, set the `TOOLBOX_PATH` environment variable and point
-`PYTHONPATH` to the python wrapper for BART:
+Once BART is installed, set the `TOOLBOX_PATH` environment variable to point to the location where the repo was cloned and `PYTHONPATH` to the python wrapper for BART:
 
 ```bash
 export TOOLBOX_PATH=/path/to/bart
 export PYTHONPATH=${TOOLBOX_PATH}/python:${PYTHONPATH}
 ```
+
+where `/path/to/bart` is the path to the cloned BART repository, not your OS installed BART program.
 
 To run the reconstruction algorithm on the validation data, run:
 
@@ -26,7 +27,7 @@ To run the reconstruction algorithm on the validation data, run:
 python run_bart.py \
     --challenge CHALLENGE \
     --data_path DATA \
-    --output_path reconstructions_val \
+    --out_path reconstructions_val \
     --reg_wt 0.01 \
     --mask_type MASK_TYPE \
     --split val
@@ -49,7 +50,7 @@ To apply the reconstruction algorithm to the test data, run:
 python run_bart.py \
     --challenge CHALLENGE \
     --data_path DATA \
-    --output_path reconstructions_test \
+    --out_path reconstructions_test \
     --split test
 ```
 

--- a/fastmri_examples/cs/run_bart.py
+++ b/fastmri_examples/cs/run_bart.py
@@ -191,7 +191,7 @@ def run_bart(args):
             time_taken = time.perf_counter() - start_time
 
     logging.info(f"Run Time = {time_taken:} s")
-    save_outputs(outputs, args.out_path)
+    save_outputs(outputs, args.output_path)
 
 
 def create_arg_parser():
@@ -204,7 +204,7 @@ def create_arg_parser():
         help="Path to the data",
     )
     parser.add_argument(
-        "--out_path",
+        "--output_path",
         type=pathlib.Path,
         required=True,
         help="Path to save the reconstructions to",

--- a/fastmri_examples/zero_filled/README.md
+++ b/fastmri_examples/zero_filled/README.md
@@ -10,7 +10,7 @@ To generate the zero-filled submissions, run:
 python run_zero_filled.py \
     --challenge CHALLENGE \
     --data_path DATA \
-    --out_path RECONS
+    --output_path RECONS
 ```
 
 where `CHALLENGE` is either `singlecoil` or `multicoil`.

--- a/fastmri_examples/zero_filled/run_zero_filled.py
+++ b/fastmri_examples/zero_filled/run_zero_filled.py
@@ -63,7 +63,7 @@ def create_arg_parser():
         help="Path to the data",
     )
     parser.add_argument(
-        "--out_path",
+        "--output_path",
         type=Path,
         required=True,
         help="Path to save the reconstructions to",
@@ -80,4 +80,4 @@ def create_arg_parser():
 
 if __name__ == "__main__":
     args = create_arg_parser().parse_args()
-    save_zero_filled(args.data_path, args.out_path, args.challenge)
+    save_zero_filled(args.data_path, args.output_path, args.challenge)


### PR DESCRIPTION
Fix output path mentioned in the [CS example README](https://github.com/facebookresearch/fastMRI/tree/master/fastmri_examples/cs) to match the one required in [run_bart.py](https://github.com/facebookresearch/fastMRI/blob/master/fastmri_examples/cs/run_bart.py).

Changed from `output_path` to `out_path` and detailed a bit more the `TOOLBOX_PATH` environmental 
variable setting.

Both the CS and Zero Filled experiments use `out_path` whilst UNet and VarNet use `output_path`. Maybe we could standardize into one of them?