### PR TITLE
Add packaging to setup requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ runstats==1.8.0
 pytorch_lightning==1.0.6
 h5py==2.10.0
 PyYAML==5.4
+packaging==21.0

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ install_requires = [
     "pytorch_lightning>=1.0.6,<1.1",
     "h5py>=2.10.0",
     "PyYAML>=5.3.1",
+    "packaging>=21.0",
 ]
 
 setup(


### PR DESCRIPTION
Fixes an issue that can occur with PyPI installation where `packaging` is not already installed.