### PR TITLE
Fix typo in varnet.py

### DIFF
--- a/fastmri/models/varnet.py
+++ b/fastmri/models/varnet.py
@@ -201,7 +201,7 @@ class VarNet(nn.Module):
     A full variational network model.
 
     This model applies a combination of soft data consistency with a U-Net
-    regularizer. To use non-U-Net regularizers, use VarNetBock.
+    regularizer. To use non-U-Net regularizers, use VarNetBlock.
     """
 
     def __init__(


### PR DESCRIPTION
`VarNetBock` should be `VarNetBlock`, as seen in
https://github.com/facebookresearch/fastMRI/blob/a588fb1b7980175e6fe6b17497148e02daf31c12/fastmri/models/varnet.py#L243
