### PR TITLE
Add batching capability for VarNet mask

### DIFF
--- a/fastmri/data/transforms.py
+++ b/fastmri/data/transforms.py
@@ -100,6 +100,31 @@ def mask_center(x: torch.Tensor, mask_from: int, mask_to: int) -> torch.Tensor:
     return mask
 
 
+def batched_mask_center(
+    x: torch.Tensor, mask_from: torch.Tensor, mask_to: torch.Tensor
+) -> torch.Tensor:
+    """
+    Initializes a mask with the center filled in.
+
+    Can operate with different masks for each batch element.
+
+    Args:
+        mask_from: Part of center to start filling.
+        mask_to: Part of center to end filling.
+
+    Returns:
+        A mask with the center filled.
+    """
+    if (not x.shape[0] == mask_from.shape[0]) or (not x.shape[0] == mask_to.shape[0]):
+        raise ValueError("mask_from and mask_to must have batch_size length.")
+
+    mask = torch.zeros_like(x)
+    for i, (start, end) in enumerate(zip(mask_from, mask_to)):
+        mask[i, :, :, start:end] = x[i, :, :, start:end]
+
+    return mask
+
+
 def center_crop(data: torch.Tensor, shape: Tuple[int, int]) -> torch.Tensor:
     """
     Apply a center crop to the input real image or batch of real images.

--- a/fastmri/data/transforms.py
+++ b/fastmri/data/transforms.py
@@ -115,8 +115,10 @@ def batched_mask_center(
     Returns:
         A mask with the center filled.
     """
-    if not mask_from.shape[0] == mask_to.shape[0]:
+    if not mask_from.shape == mask_to.shape:
         raise ValueError("mask_from and mask_to must match shapes.")
+    if not mask_from.ndim == 1:
+        raise ValueError("mask_from and mask_to must have 1 dimension.")
     if not mask_from.shape[0] == 1:
         if (not x.shape[0] == mask_from.shape[0]) or (
             not x.shape[0] == mask_to.shape[0]

--- a/fastmri/data/transforms.py
+++ b/fastmri/data/transforms.py
@@ -115,12 +115,20 @@ def batched_mask_center(
     Returns:
         A mask with the center filled.
     """
-    if (not x.shape[0] == mask_from.shape[0]) or (not x.shape[0] == mask_to.shape[0]):
-        raise ValueError("mask_from and mask_to must have batch_size length.")
+    if not mask_from.shape[0] == mask_to.shape[0]:
+        raise ValueError("mask_from and mask_to must match shapes.")
+    if not mask_from.shape[0] == 1:
+        if (not x.shape[0] == mask_from.shape[0]) or (
+            not x.shape[0] == mask_to.shape[0]
+        ):
+            raise ValueError("mask_from and mask_to must have batch_size length.")
 
-    mask = torch.zeros_like(x)
-    for i, (start, end) in enumerate(zip(mask_from, mask_to)):
-        mask[i, :, :, start:end] = x[i, :, :, start:end]
+    if mask_from.shape[0] == 1:
+        mask = mask_center(x, int(mask_from), int(mask_to))
+    else:
+        mask = torch.zeros_like(x)
+        for i, (start, end) in enumerate(zip(mask_from, mask_to)):
+            mask[i, :, :, start:end] = x[i, :, :, start:end]
 
     return mask
 

--- a/fastmri/models/varnet.py
+++ b/fastmri/models/varnet.py
@@ -180,13 +180,11 @@ class SensitivityModel(nn.Module):
         cent = squeezed_mask.shape[1] // 2
         left = cent - torch.min(torch.argmin(squeezed_mask[:, :cent].flip(1), dim=1))
         right = cent + torch.min(torch.argmin(squeezed_mask[:, cent:], dim=1))
-        num_low_freqs = right - left
-        pad = (mask.shape[-2] - num_low_freqs + 1) // 2
 
-        if not torch.all(squeezed_mask[:, pad : pad + num_low_freqs] == 1):
+        if not torch.all(squeezed_mask[:, left:right] == 1):  # type: ignore
             raise RuntimeError("Extracting k-space center failed.")
 
-        x = transforms.mask_center(masked_kspace, pad, pad + num_low_freqs)
+        x = transforms.mask_center(masked_kspace, left, right)  # type: ignore
 
         # convert to image space
         x = fastmri.ifft2c(x)

--- a/fastmri/models/varnet.py
+++ b/fastmri/models/varnet.py
@@ -178,6 +178,7 @@ class SensitivityModel(nn.Module):
         # get low frequency line locations and mask them out
         squeezed_mask = mask[:, 0, 0, :, 0]
         cent = squeezed_mask.shape[1] // 2
+        # running argmin returns the first non-zero
         left = cent - torch.min(torch.argmin(squeezed_mask[:, :cent].flip(1), dim=1))
         right = cent + torch.min(torch.argmin(squeezed_mask[:, cent:], dim=1))
 

--- a/fastmri/models/varnet.py
+++ b/fastmri/models/varnet.py
@@ -181,9 +181,9 @@ class SensitivityModel(nn.Module):
         # running argmin returns the first non-zero
         left = torch.argmin(squeezed_mask[:, :cent].flip(1), dim=1)
         right = torch.argmin(squeezed_mask[:, cent:], dim=1)
-        num_low_freqs = 2 * torch.max(
-            torch.min(left, right), torch.ones_like(left)
-        )  # force a symmetric center
+        num_low_freqs = torch.max(
+            2 * torch.min(left, right), torch.ones_like(left)
+        )  # force a symmetric center unless 1
         pad = (mask.shape[-2] - num_low_freqs + 1) // 2
 
         x = transforms.batched_mask_center(masked_kspace, pad, pad + num_low_freqs)

--- a/fastmri/models/varnet.py
+++ b/fastmri/models/varnet.py
@@ -181,7 +181,9 @@ class SensitivityModel(nn.Module):
         # running argmin returns the first non-zero
         left = torch.argmin(squeezed_mask[:, :cent].flip(1), dim=1)
         right = torch.argmin(squeezed_mask[:, cent:], dim=1)
-        num_low_freqs = 2 * torch.min(left, right)  # force a symmetric center
+        num_low_freqs = 2 * torch.max(
+            torch.min(left, right), torch.ones_like(left)
+        )  # force a symmetric center
         pad = (mask.shape[-2] - num_low_freqs + 1) // 2
 
         x = transforms.batched_mask_center(masked_kspace, pad, pad + num_low_freqs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -47,7 +47,14 @@ def test_unet(shape, out_chans, chans):
 def test_varnet(shape, out_chans, chans, center_fractions, accelerations):
     mask_func = RandomMaskFunc(center_fractions, accelerations)
     x = create_input(shape)
-    output, mask = transforms.apply_mask(x, mask_func, seed=123)
+    outputs, masks = [], []
+    for i in range(x.shape[0]):
+        output, mask = transforms.apply_mask(x[i : i + 1], mask_func, seed=123)
+        outputs.append(output)
+        masks.append(mask)
+
+    output = torch.cat(outputs)
+    mask = torch.cat(masks)
 
     varnet = VarNet(num_cascades=2, sens_chans=4, sens_pools=2, chans=4, pools=2)
 


### PR DESCRIPTION
This adds batching capability for the VarNet mask. There is a bit of a question of how to handle cases where a sample is selected right next to the densely sampled region. To give an example, you may have R=4 and a densely-sampled region of 8. It's possible for one line of your R=4 to be next to the R=8 group. In that case, this code will select 9 lines for a batch size of 1. Using a batch size of greater than 1 introduces some randomness. The code is conservative and will generally pick 8 lines in that case.

One way to solve this might be to only allow even numbers of central k-space lines, which might give a bit more simplicity for this phenomenon. The effects are probably measurable, but small, considering this is just input to a neural network.

Note: we still expect this to only work in the magical scenario where all the k-space sizes are the same.