### PR TITLE
No Shuffle for samplers and loaders in data module for test and validation

### DIFF
--- a/fastmri/pl_modules/data_module.py
+++ b/fastmri/pl_modules/data_module.py
@@ -201,7 +201,7 @@ class FastMriDataModule(pl.LightningDataModule):
             if is_train:
                 sampler = torch.utils.data.DistributedSampler(dataset)
             else:
-                sampler = fastmri.data.VolumeSampler(dataset)
+                sampler = fastmri.data.VolumeSampler(dataset, shuffle=False)
 
         dataloader = torch.utils.data.DataLoader(
             dataset=dataset,
@@ -209,6 +209,7 @@ class FastMriDataModule(pl.LightningDataModule):
             num_workers=self.num_workers,
             worker_init_fn=worker_init_fn,
             sampler=sampler,
+            shuffle=is_train,
         )
 
         return dataloader

--- a/fastmri/pl_modules/data_module.py
+++ b/fastmri/pl_modules/data_module.py
@@ -209,7 +209,7 @@ class FastMriDataModule(pl.LightningDataModule):
             num_workers=self.num_workers,
             worker_init_fn=worker_init_fn,
             sampler=sampler,
-            shuffle=is_train,
+            shuffle=is_train if sampler is None else False,
         )
 
         return dataloader


### PR DESCRIPTION
This would allow the use of the [`predict`](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#predict) method from the ptl trainer in order to evaluate the data volume-wise.

I think it would also not cause any issue because the validation data does not need to be shuffled unlike the training data.

I didn't open an issue because this is such a small PR, but glad to if needed.