### PR TITLE
num_workers in data_module is now an int instead of float

### DIFF
--- a/fastmri/pl_modules/data_module.py
+++ b/fastmri/pl_modules/data_module.py
@@ -327,7 +327,7 @@ class FastMriDataModule(pl.LightningDataModule):
         parser.add_argument(
             "--num_workers",
             default=4,
-            type=float,
+            type=int,
             help="Number of workers to use in data loader",
         )
 


### PR DESCRIPTION
`num_workers` was a `float` argparse arg, which threw errors when setting it through command line. 