### PR TITLE
Changed EquispacedMaskFunc

### DIFF
--- a/fastmri/data/subsample.py
+++ b/fastmri/data/subsample.py
@@ -155,6 +155,39 @@ class EquispacedMaskFunc(MaskFunc):
     modifications to standard GRAPPA approaches. Nonetheless, this aspect of
     the function has been preserved to match the public multicoil data.
     """
+    def __init__(
+            self, 
+            center_fractions: Sequence[float], 
+            accelerations: Sequence[int], 
+            skip_low_freqs: Optional[bool] = False,
+            skip_around_low_freqs: Optional[bool] = False,
+        ):
+        """
+        Args:
+            center_fractions: Fraction of low-frequency columns to be retained.
+                If multiple values are provided, then one of these numbers is
+                chosen uniformly each time.
+            accelerations: Amount of under-sampling. This should have the same
+                length as center_fractions. If multiple values are provided,
+                then one of these is chosen uniformly each time.
+            skip_low_freqs: Whether to skip already sampled low-frequency lines
+                            for the purposes of determining where equispaced lines
+                            should be. Set this `True` to guarantee the same number
+                            of sampled lines for all masks with a given (acceleration,
+                            center_fraction) setting.
+            skip_around_low_freqs: Whether to also skip the two k-space lines right
+                                   next to the already sampled low-frequency region.
+                                   Used to guarantee that equispaced sampling doesn't 
+                                   extend the low-frequency region. This is mostly useful
+                                   for VarNet, since it guarantees the same number of low-
+                                   frequency lines are used for the sensitivity map calculation
+                                   for all masks with a given (acceleration, center_fraction) 
+                                   setting. This argument has no effect when `skip_low_freqs`
+                                   is `False`. 
+        """
+        super().__init__(center_fractions, accelerations)
+        self.skip_low_freqs = skip_low_freqs
+        self.skip_around_low_freqs = skip_around_low_freqs
 
     def __call__(
         self, shape: Sequence[int], seed: Optional[Union[int, Tuple[int, ...]]] = None
@@ -184,15 +217,41 @@ class EquispacedMaskFunc(MaskFunc):
             pad = (num_cols - num_low_freqs + 1) // 2
             mask[pad : pad + num_low_freqs] = True
 
-            # determine acceleration rate by adjusting for the number of low frequencies
-            adjusted_accel = (acceleration * (num_low_freqs - num_cols)) / (
-                num_low_freqs * acceleration - num_cols
-            )
-            offset = self.rng.randint(0, round(adjusted_accel))
+            # If everything has been sampled in the center: we don't need to sample anything else.
+            if num_low_freqs * acceleration != num_cols:
+                if self.skip_low_freqs:
+                    buffer = 0
+                    if self.skip_around_low_freqs:
+                        buffer = 2
+                    # Compute the adjusted acceleration according to having 
+                    #  (num_low_freqs + buffer) center lines.
+                    adjusted_accel = (acceleration * (num_low_freqs + buffer - num_cols)) / (
+                        num_low_freqs * acceleration - num_cols
+                    )
+                    offset = self.rng.randint(0, round(adjusted_accel) - 1)
 
-            accel_samples = np.arange(offset, num_cols - 1, adjusted_accel)
-            accel_samples = np.around(accel_samples).astype(np.uint)
-            mask[accel_samples] = True
+                    # Select samples from the remaining columns
+                    accel_samples = np.arange(
+                        offset, num_cols - num_low_freqs - buffer - 1, adjusted_accel
+                    )
+                    accel_samples = np.around(accel_samples).astype(np.uint)
+
+                    skip = num_low_freqs + buffer  # Skip low freq AND optionally lines right next to it
+                    for sample in accel_samples:
+                        if sample < pad - buffer // 2:
+                            mask[sample] = True
+                        else:  # sample is further than center, so skip low_freqs
+                            mask[int(sample + skip)] = True
+                else:  # Default behaviour
+                    # determine acceleration rate by adjusting for the number of low frequencies
+                    adjusted_accel = (acceleration * (num_low_freqs - num_cols)) / (
+                        num_low_freqs * acceleration - num_cols
+                    )
+                    offset = self.rng.randint(0, round(adjusted_accel))
+
+                    accel_samples = np.arange(offset, num_cols - 1, adjusted_accel)
+                    accel_samples = np.around(accel_samples).astype(np.uint)
+                    mask[accel_samples] = True
 
             # reshape the mask
             mask_shape = [1 for _ in shape]
@@ -205,7 +264,9 @@ class EquispacedMaskFunc(MaskFunc):
 def create_mask_for_mask_type(
     mask_type_str: str,
     center_fractions: Sequence[float],
-    accelerations: Sequence[int],
+    accelerations: Sequence[int], 
+    skip_low_freqs: Optional[bool] = False,
+    skip_around_low_freqs: Optional[bool] = False,
 ) -> MaskFunc:
     """
     Creates a mask of the specified type.
@@ -213,10 +274,14 @@ def create_mask_for_mask_type(
     Args:
         center_fractions: What fraction of the center of k-space to include.
         accelerations: What accelerations to apply.
+        skip_low_freqs: Only used for EquispacedMaskFunc.
+        skip_around_low_freqs: Only used for EquispacedMaskFunc.
     """
     if mask_type_str == "random":
         return RandomMaskFunc(center_fractions, accelerations)
     elif mask_type_str == "equispaced":
-        return EquispacedMaskFunc(center_fractions, accelerations)
+        return EquispacedMaskFunc(
+            center_fractions, accelerations, skip_low_freqs, skip_around_low_freqs
+        )
     else:
         raise Exception(f"{mask_type_str} not supported")


### PR DESCRIPTION
- now has expected behaviour when the center_fraction is 1 / acceleration.

- added optional `skip_low_freqs` flag to guarantee fixed number of lines sampled per (acceleration, center_fraction) pair.

- added optional `skip_around_low_freqs` to act in combination with `skip_low_freqs` for the VarNet, guaranteeing the same number of low-frequency lines are used for all slices in the sensitivity mask calculation.