### PR TITLE
Update for subsample masking API

### DIFF
--- a/fastmri/__init__.py
+++ b/fastmri/__init__.py
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-__version__ = "0.1.2a20210917"
+__version__ = "0.1.2a20210917b"
 __author__ = "Facebook/NYU fastMRI Team"
 __author_email__ = "fastmri@fb.com"
 __license__ = "MIT"

--- a/fastmri_examples/unet/train_unet_demo.py
+++ b/fastmri_examples/unet/train_unet_demo.py
@@ -101,7 +101,7 @@ def build_args():
     # data transform params
     parser.add_argument(
         "--mask_type",
-        choices=("random", "equispaced"),
+        choices=("random", "equispaced_fraction"),
         default="random",
         type=str,
         help="Type of k-space mask",

--- a/fastmri_examples/varnet/train_varnet_demo.py
+++ b/fastmri_examples/varnet/train_varnet_demo.py
@@ -101,8 +101,8 @@ def build_args():
     # data transform params
     parser.add_argument(
         "--mask_type",
-        choices=("random", "equispaced"),
-        default="equispaced",
+        choices=("random", "equispaced_fraction"),
+        default="equispaced_fraction",
         type=str,
         help="Type of k-space mask",
     )
@@ -125,7 +125,7 @@ def build_args():
     parser = FastMriDataModule.add_data_specific_args(parser)
     parser.set_defaults(
         data_path=data_path,  # path to fastMRI data
-        mask_type="equispaced",  # VarNet uses equispaced mask
+        mask_type="equispaced_fraction",  # VarNet uses equispaced mask
         challenge="multicoil",  # only multicoil implemented for VarNet
         batch_size=batch_size,  # number of samples per batch
         test_path=None,  # path for test split, overwrites data_path

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,7 +50,7 @@ def test_varnet(shape, chans, center_fractions, accelerations, mask_center):
     x = create_input(shape)
     outputs, masks = [], []
     for i in range(x.shape[0]):
-        output, mask = transforms.apply_mask(x[i : i + 1], mask_func, seed=123)
+        output, mask, _ = transforms.apply_mask(x[i : i + 1], mask_func, seed=123)
         outputs.append(output)
         masks.append(mask)
 
@@ -85,7 +85,7 @@ def test_varnet_num_sense_lines(
     x = create_input(shape)
     outputs, masks = [], []
     for i in range(x.shape[0]):
-        output, mask = transforms.apply_mask(x[i : i + 1], mask_func, seed=123)
+        output, mask, _ = transforms.apply_mask(x[i : i + 1], mask_func, seed=123)
         outputs.append(output)
         masks.append(mask)
 
@@ -98,11 +98,10 @@ def test_varnet_num_sense_lines(
         sens_pools=2,
         chans=chans,
         pools=2,
-        num_sense_lines=4,
         mask_center=mask_center,
     )
 
-    y = varnet(output, mask.byte())
+    y = varnet(output, mask.byte(), num_low_frequencies=4)
 
     assert y.shape[1:] == x.shape[2:4]
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -21,15 +21,16 @@ def test_apply_mask(shape, center_fractions, accelerations):
     state = np.random.get_state()
 
     mask_func = RandomMaskFunc(center_fractions, accelerations)
-    expected_mask = mask_func(shape, seed=123)
+    expected_mask, expected_num_low_frequencies = mask_func(shape, seed=123)
     x = create_input(shape)
-    output, mask = transforms.apply_mask(x, mask_func, seed=123)
+    output, mask, num_low_frequencies = transforms.apply_mask(x, mask_func, seed=123)
 
     assert (state[1] == np.random.get_state()[1]).all()
     assert output.shape == x.shape
     assert mask.shape == expected_mask.shape
     assert np.all(expected_mask.numpy() == mask.numpy())
     assert np.all(np.where(mask.numpy() == 0, 0, output.numpy()) == output.numpy())
+    assert num_low_frequencies == expected_num_low_frequencies
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This update implements a major overhaul of the masking API for the repository. The primary reason for doing this was to implement the [magic mask](https://arxiv.org/abs/1912.01101) in the core repository. Already, we had repeated code in several sections, and with the new mask this would be duplicated again and be bad for maintenance. With the new code structure, everything is subclassed from a base mask function in a modular way, so for the future we'll hopefully only need to change the base class to make updates.

We also implemented a few other things that came from the internal fastMRI repository (most of which has already been exposed via `banding_removal`). These include returning the number of low frequency lines (for sensitivity map estimation) and segmenting out the equispaced mask from the pseudo-equispaced mask mentioned in Issue #54.

**Note: for the old equispaced mask behavior, you now need to use `EquispacedMaskFraction`. `EquispacedMask` now implements exactly an equispaced mask, as its title suggests. The VarNet and U-Net examples should be updated accordingly with this PR.**

Lastly, this PR updates the test environment to bring all dependencies up to date for September 2021 for unit testing. It supersedes #166, as it seems the `mypy` update required changes to several parts of the code, so I thought it was easier to include here.

CC @adefazio @Timsey 