### PR TITLE
Update requirements for test and install

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ pytest==6.2.4
 mypy==0.910
 black==21.4b2
 flake8==3.9.0
+types-pyyaml==5.4.10

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 wheel
-pytest==5.4.3
-mypy==0.800
-black==20.8b1
-flake8==3.8.3
+pytest==6.2.4
+mypy==0.910
+black==21.4b2
+flake8==3.9.0

--- a/fastmri/__init__.py
+++ b/fastmri/__init__.py
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-__version__ = "0.1.2a20210721"
+__version__ = "0.1.2a20210914"
 __author__ = "Facebook/NYU fastMRI Team"
 __author_email__ = "fastmri@fb.com"
 __license__ = "MIT"

--- a/fastmri/__init__.py
+++ b/fastmri/__init__.py
@@ -12,10 +12,12 @@ __license__ = "MIT"
 __homepage__ = "https://fastmri.org/"
 
 import torch
-from packaging import version
 
 from .coil_combine import rss, rss_complex
-from .fftc import fftshift, ifftshift, roll
+from .fftc import fft2c_new as fft2c
+from .fftc import fftshift
+from .fftc import ifft2c_new as ifft2c
+from .fftc import ifftshift, roll
 from .losses import SSIMLoss
 from .math import (
     complex_abs,
@@ -25,10 +27,3 @@ from .math import (
     tensor_to_complex_np,
 )
 from .utils import convert_fnames_to_v2, save_reconstructions
-
-if version.parse(torch.__version__) >= version.parse("1.7.0"):
-    from .fftc import fft2c_new as fft2c
-    from .fftc import ifft2c_new as ifft2c
-else:
-    from .fftc import fft2c_old as fft2c
-    from .fftc import ifft2c_old as ifft2c

--- a/fastmri/data/subsample.py
+++ b/fastmri/data/subsample.py
@@ -13,7 +13,7 @@ import torch
 
 
 @contextlib.contextmanager
-def temp_seed(rng: np.random, seed: Optional[Union[int, Tuple[int, ...]]]):
+def temp_seed(rng: np.random.Generator, seed: Optional[Union[int, Tuple[int, ...]]]):
     if seed is None:
         try:
             yield
@@ -257,9 +257,9 @@ class EquispacedMaskFunc(MaskFunc):
             # reshape the mask
             mask_shape = [1 for _ in shape]
             mask_shape[-2] = num_cols
-            mask = torch.from_numpy(mask.reshape(*mask_shape).astype(np.float32))
+            mask_np = torch.from_numpy(mask.reshape(*mask_shape).astype(np.float32))
 
-        return mask
+        return mask_np
 
 
 def create_mask_for_mask_type(

--- a/fastmri/evaluate.py
+++ b/fastmri/evaluate.py
@@ -48,7 +48,7 @@ def ssim(
 
     maxval = gt.max() if maxval is None else maxval
 
-    ssim = 0
+    ssim = np.array([0])
     for slice_num in range(gt.shape[0]):
         ssim = ssim + structural_similarity(
             gt[slice_num], pred[slice_num], data_range=maxval

--- a/fastmri/fftc.py
+++ b/fastmri/fftc.py
@@ -8,65 +8,7 @@ LICENSE file in the root directory of this source tree.
 from typing import List, Optional
 
 import torch
-from packaging import version
-
-if version.parse(torch.__version__) >= version.parse("1.7.0"):
-    import torch.fft  # type: ignore
-
-
-def fft2c_old(data: torch.Tensor, norm: str = "ortho") -> torch.Tensor:
-    """
-    Apply centered 2 dimensional Fast Fourier Transform.
-
-    Args:
-        data: Complex valued input data containing at least 3 dimensions:
-            dimensions -3 & -2 are spatial dimensions and dimension -1 has size
-            2. All other dimensions are assumed to be batch dimensions.
-        norm: Whether to include normalization. Must be one of ``"backward"``
-            or ``"ortho"``. See ``torch.fft.fft`` on PyTorch 1.9.0 for details.
-
-    Returns:
-        The FFT of the input.
-    """
-    if not data.shape[-1] == 2:
-        raise ValueError("Tensor does not have separate complex dim.")
-    if norm not in ("ortho", "backward"):
-        raise ValueError("norm must be 'ortho' or 'backward'.")
-    normalized = True if norm == "ortho" else False
-
-    data = ifftshift(data, dim=[-3, -2])
-    data = torch.fft(data, 2, normalized=normalized)
-    data = fftshift(data, dim=[-3, -2])
-
-    return data
-
-
-def ifft2c_old(data: torch.Tensor, norm: str = "ortho") -> torch.Tensor:
-    """
-    Apply centered 2-dimensional Inverse Fast Fourier Transform.
-
-    Args:
-        data: Complex valued input data containing at least 3 dimensions:
-            dimensions -3 & -2 are spatial dimensions and dimension -1 has size
-            2. All other dimensions are assumed to be batch dimensions.
-        norm: Whether to include normalization. Must be one of ``"backward"``
-            or ``"ortho"``. See ``torch.fft.ifft`` on PyTorch 1.9.0 for
-            details.
-
-    Returns:
-        The IFFT of the input.
-    """
-    if not data.shape[-1] == 2:
-        raise ValueError("Tensor does not have separate complex dim.")
-    if norm not in ("ortho", "backward"):
-        raise ValueError("norm must be 'ortho' or 'backward'.")
-    normalized = True if norm == "ortho" else False
-
-    data = ifftshift(data, dim=[-3, -2])
-    data = torch.ifft(data, 2, normalized=normalized)
-    data = fftshift(data, dim=[-3, -2])
-
-    return data
+import torch.fft
 
 
 def fft2c_new(data: torch.Tensor, norm: str = "ortho") -> torch.Tensor:

--- a/fastmri/math.py
+++ b/fastmri/math.py
@@ -96,6 +96,4 @@ def tensor_to_complex_np(data: torch.Tensor) -> np.ndarray:
     Returns:
         Complex numpy version of data.
     """
-    data = data.numpy()
-
-    return data[..., 0] + 1j * data[..., 1]
+    return torch.view_as_complex(data).numpy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-numpy==1.18.5
+numpy==1.20.3
 scikit_image==0.16.2
-torchvision==0.8.1
-torch==1.7.0
-runstats==1.8.0
-pytorch_lightning==1.0.6
+torchvision==0.10.0
+torch==1.9.0
+runstats==2.0.0
+pytorch_lightning==1.0.8
 h5py==2.10.0
-PyYAML==5.4
-packaging==21.0
+PyYAML==5.4.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ install_requires = [
     "pytorch_lightning>=1.0.6,<1.1",
     "h5py>=2.10.0",
     "PyYAML>=5.3.1",
-    "packaging>=21.0",
 ]
 
 setup(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -15,10 +15,7 @@ from .conftest import create_input
 
 @pytest.mark.parametrize(
     "shape, center_fractions, accelerations",
-    [
-        ([4, 32, 32, 2], [0.08], [4]),
-        ([2, 64, 64, 2], [0.04, 0.08], [8, 4]),
-    ],
+    [([4, 32, 32, 2], [0.08], [4]), ([2, 64, 64, 2], [0.04, 0.08], [8, 4])],
 )
 def test_apply_mask(shape, center_fractions, accelerations):
     state = np.random.get_state()
@@ -36,12 +33,7 @@ def test_apply_mask(shape, center_fractions, accelerations):
 
 
 @pytest.mark.parametrize(
-    "shape, target_shape",
-    [
-        [[10, 10], [4, 4]],
-        [[4, 6], [2, 4]],
-        [[8, 4], [4, 4]],
-    ],
+    "shape, target_shape", [[[10, 10], [4, 4]], [[4, 6], [2, 4]], [[8, 4], [4, 4]]]
 )
 def test_center_crop(shape, target_shape):
     x = create_input(shape)
@@ -51,12 +43,7 @@ def test_center_crop(shape, target_shape):
 
 
 @pytest.mark.parametrize(
-    "shape, target_shape",
-    [
-        [[10, 10], [4, 4]],
-        [[4, 6], [2, 4]],
-        [[8, 4], [4, 4]],
-    ],
+    "shape, target_shape", [[[10, 10], [4, 4]], [[4, 6], [2, 4]], [[8, 4], [4, 4]]]
 )
 def test_complex_center_crop(shape, target_shape):
     shape = shape + [2]
@@ -69,12 +56,7 @@ def test_complex_center_crop(shape, target_shape):
 
 
 @pytest.mark.parametrize(
-    "shape, mean, stddev",
-    [
-        [[10, 10], 0, 1],
-        [[4, 6], 4, 10],
-        [[8, 4], 2, 3],
-    ],
+    "shape, mean, stddev", [[[10, 10], 0, 1], [[4, 6], 4, 10], [[8, 4], 2, 3]]
 )
 def test_normalize(shape, mean, stddev):
     x = create_input(shape)
@@ -84,13 +66,7 @@ def test_normalize(shape, mean, stddev):
     assert np.isclose(output.std(), x.numpy().std() / stddev)
 
 
-@pytest.mark.parametrize(
-    "shape",
-    [
-        [10, 10],
-        [20, 40, 30],
-    ],
-)
+@pytest.mark.parametrize("shape", [[10, 10], [20, 40, 30]])
 def test_normalize_instance(shape):
     x = create_input(shape)
     output, mean, stddev = transforms.normalize_instance(x)


### PR DESCRIPTION
This splits off the test requirements update from #167 to reduce the number of files modified in that diff. It supersedes #166.

- There are several changes due to the `mypy` update, which caught a few new issues with type annotations. In general strict type adherence is best, so we've created some new variables for things such as `Tensor` conversion (specifically, in `UnetDataTransform` and `VarNetDataTransform`).
- Since we now have a standardized requirements framework and versioning we can drop support for pre-1.7.0 PyTorch FFTs and drop `packaging` as a requirement.