### PR TITLE
Add masking tests, remove unnecessary num_sens_lines

### DIFF
--- a/fastmri/models/varnet.py
+++ b/fastmri/models/varnet.py
@@ -142,7 +142,6 @@ class SensitivityModel(nn.Module):
         out_chans: int = 2,
         drop_prob: float = 0.0,
         mask_center: bool = True,
-        num_sense_lines: Optional[int] = None,
     ):
         """
         Args:
@@ -153,14 +152,8 @@ class SensitivityModel(nn.Module):
             drop_prob: Dropout probability.
             mask_center: Whether to mask center of k-space for sensitivity map
                 calculation.
-            num_sense_lines: Number of low-frequency lines to use for
-                sensitivity map computation, must be even or ``None``. Default
-                ``None`` will automatically compute the number from masks by
-                using the largest even, continuous region possible from the
-                k-space center.
         """
         super().__init__()
-        self.num_sense_lines = num_sense_lines
         self.mask_center = mask_center
         self.norm_unet = NormUnet(
             chans,

--- a/fastmri/models/varnet.py
+++ b/fastmri/models/varnet.py
@@ -182,7 +182,7 @@ class SensitivityModel(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if num_low_frequencies is None:
             # get low frequency line locations and mask them out
-            squeezed_mask = mask[:, 0, 0, :, 0]
+            squeezed_mask = mask[:, 0, 0, :, 0].to(torch.int8)
             cent = squeezed_mask.shape[1] // 2
             # running argmin returns the first non-zero
             left = torch.argmin(squeezed_mask[:, :cent].flip(1), dim=1)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -15,13 +15,16 @@ from .conftest import create_input
 
 @pytest.mark.parametrize(
     "shape, center_fractions, accelerations",
-    [([4, 32, 32, 2], [0.08], [4]), ([2, 64, 64, 2], [0.04, 0.08], [8, 4])],
+    [([4, 150, 75, 2], [0.08], [4]), ([2, 120, 60, 2], [0.04, 0.08], [8, 4])],
 )
 def test_apply_mask(shape, center_fractions, accelerations):
     state = np.random.get_state()
 
     mask_func = RandomMaskFunc(center_fractions, accelerations)
     expected_mask, expected_num_low_frequencies = mask_func(shape, seed=123)
+    assert expected_num_low_frequencies in [
+        round(cf * shape[-2]) for cf in center_fractions
+    ]
     x = create_input(shape)
     output, mask, num_low_frequencies = transforms.apply_mask(x, mask_func, seed=123)
 


### PR DESCRIPTION
`num_sense_lines` is no longer used, so let's get rid of it.

This PR also introduces some new tests to assert that the VarNet masking operations select the center lines correctly, as well as making sure that masks correctly sample the center.