### PR TITLE
Allow different-length center fractions/accelerations

### DIFF
--- a/fastmri/data/subsample.py
+++ b/fastmri/data/subsample.py
@@ -53,6 +53,7 @@ class MaskFunc:
         center_fractions: Sequence[float],
         accelerations: Sequence[int],
         sync_center_fractions_accelerations: bool = True,
+        seed: Optional[int] = None,
     ):
         """
         Args:
@@ -68,6 +69,8 @@ class MaskFunc:
                 ``sync_center_fractions_accelerations`` is ``True``, then the
                 first element of ``center_fractions`` will only be selected
                 with the first element of ``accelerations``, etc.
+            seed: Seed for starting the internal random number generator of the
+                ``MaskFunc``.
         """
         if (
             not len(center_fractions) == len(accelerations)
@@ -80,7 +83,7 @@ class MaskFunc:
         self.center_fractions = center_fractions
         self.accelerations = accelerations
         self.sync_center_fractions_accelerations = sync_center_fractions_accelerations
-        self.rng = np.random.RandomState()
+        self.rng = np.random.RandomState(seed)
 
     def __call__(
         self,

--- a/fastmri/data/subsample.py
+++ b/fastmri/data/subsample.py
@@ -69,7 +69,9 @@ class MaskFunc:
                 first element of ``center_fractions`` will only be selected
                 with the first element of ``accelerations``, etc.
         """
-        if not len(center_fractions) == len(accelerations):
+        if (
+            not len(center_fractions) == len(accelerations)
+        ) and sync_center_fractions_accelerations:
             raise ValueError(
                 "Number of center fractions should match number of accelerations"
             )

--- a/fastmri/data/subsample.py
+++ b/fastmri/data/subsample.py
@@ -73,7 +73,8 @@ class MaskFunc:
             not len(center_fractions) == len(accelerations)
         ) and sync_center_fractions_accelerations:
             raise ValueError(
-                "Number of center fractions should match number of accelerations"
+                "Number of center fractions should match number of accelerations "
+                "if sync_center_fractions_accelerations is True."
             )
 
         self.center_fractions = center_fractions

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 import numpy as np
 import pytest
 from fastmri.data import transforms
-from fastmri.data.subsample import RandomMaskFunc, create_mask_for_mask_type
+from fastmri.data.subsample import MaskFunc, RandomMaskFunc, create_mask_for_mask_type
 
 from .conftest import create_input
 
@@ -64,6 +64,34 @@ def test_mask_types(mask_type):
                 np.where(mask.numpy() == 0, 0, output.numpy()) == output.numpy()
             )
             assert num_low_frequencies == expected_num_low_frequencies
+
+
+@pytest.mark.parametrize(
+    (
+        "sync_fractions_accel, center_fractions, accelerations, seed, "
+        "choose_acceleration_output"
+    ),
+    [
+        (False, [0.04, 0.08], [8, 4], 2, (0.04, 4)),
+        (True, [0.04, 0.08], [8, 4], 2, (0.04, 8)),
+        (False, [0.04, 0.08], [16, 8, 4], 8, (0.08, 16)),
+    ],
+)
+def test_fraction_accel_sync(
+    sync_fractions_accel,
+    center_fractions,
+    accelerations,
+    seed,
+    choose_acceleration_output,
+):
+    """For this test we have manually checked choose_acceleration_output."""
+    f = MaskFunc(
+        center_fractions=center_fractions,
+        accelerations=accelerations,
+        sync_center_fractions_accelerations=sync_fractions_accel,
+        seed=seed,
+    )
+    assert f.choose_acceleration() == choose_acceleration_output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -68,17 +68,17 @@ def test_mask_types(mask_type):
 
 @pytest.mark.parametrize(
     (
-        "sync_fractions_accel, center_fractions, accelerations, seed, "
+        "allow_any_combination, center_fractions, accelerations, seed, "
         "choose_acceleration_output"
     ),
     [
-        (False, [0.04, 0.08], [8, 4], 2, (0.04, 4)),
-        (True, [0.04, 0.08], [8, 4], 2, (0.04, 8)),
-        (False, [0.04, 0.08], [16, 8, 4], 8, (0.08, 16)),
+        (True, [0.04, 0.08], [8, 4], 2, (0.04, 4)),
+        (False, [0.04, 0.08], [8, 4], 2, (0.04, 8)),
+        (True, [0.04, 0.08], [16, 8, 4], 8, (0.08, 16)),
     ],
 )
 def test_fraction_accel_sync(
-    sync_fractions_accel,
+    allow_any_combination,
     center_fractions,
     accelerations,
     seed,
@@ -88,10 +88,17 @@ def test_fraction_accel_sync(
     f = MaskFunc(
         center_fractions=center_fractions,
         accelerations=accelerations,
-        sync_center_fractions_accelerations=sync_fractions_accel,
+        allow_any_combination=allow_any_combination,
         seed=seed,
     )
-    assert f.choose_acceleration() == choose_acceleration_output
+    if not allow_any_combination:
+        for _ in range(50):
+            center_fraction, acceleration = f.choose_acceleration()
+            assert center_fractions.index(center_fraction) == accelerations.index(
+                acceleration
+            )
+    else:
+        assert f.choose_acceleration() == choose_acceleration_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR allows the user to use different-length center-fractions and accelerations. It also allows mixing between center fractions and accelerations.

**Old Code**
For example, if the user inputs `[0.08, 0.04]` for `center_fractions` and `[4, 8]` for accelerations, under the previous code, `0.08` would always be selected with `4` and `0.04` would always be selected with `8`.

**New Code**
We have a parameter, `sync_center_fractions_accelerations` in `MaskFunc`. If `sync_center_fractions_accelerations` is `False`, then now `0.08` can be selected with `8` and `0.04` can be selected with `4`.