### PR TITLE
Update CI triggers

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,12 @@
 name: Build and Test
 
 # trigger on any PR or push
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
This updates CI to avoid duplicate triggers on `push` and `pull_request`. For the old `push` case we now ask the user to manually trigger the tests with `workflow_dispatch` using the GitHub website UI. All pull requests should still be tested.