### PR TITLE
Implement issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,11 @@
+---
+name: 'Bug report'
+about: 'Report a bug to help improve fastMRI'
+labels: 'bug'
+---
+
+Please:
+
+- [ ] Check for duplicate issues.
+- [ ] Provide a simple example for how to reproduce the bug.
+- [ ] If applicable, include full error messages/tracebacks.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,10 @@
+---
+name: 'Feature Request'
+about: 'Suggest a new idea or improvement for fastMRI'
+labels: 'enhancement'
+---
+
+Please:
+
+- [ ] Check for duplicate requests.
+- [ ] Describe your goal, and if possible provide a code snippet with a motivating example.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions
+    url: https://github.com/facebookresearch/fastMRI/discussions
+    about: Please ask questions on the Discussions tab


### PR DESCRIPTION
Implements templates for opening new issues.

Guides users to Discussions if they're not requesting a feature or documenting a bug.