### PR TITLE
Add a dummy to the return of the apply_mask function to prevent errors

### DIFF
--- a/fastMRI_tutorial.ipynb
+++ b/fastMRI_tutorial.ipynb
@@ -247,9 +247,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.2 64-bit ('fastmri': conda)",
    "language": "python",
-   "name": "python3"
+   "name": "python38264bitfastmricondae6ff12e14a6d4c7fab7686eaa5d0b897"
   },
   "language_info": {
    "codemirror_mode": {
@@ -261,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.11"
+   "version": "3.7.7-final"
   }
  },
  "nbformat": 4,

--- a/fastMRI_tutorial.ipynb
+++ b/fastMRI_tutorial.ipynb
@@ -207,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "masked_kspace, mask = T.apply_mask(slice_kspace2, mask_func)   # Apply the mask to k-space"
+    "masked_kspace, mask, _ = T.apply_mask(slice_kspace2, mask_func)   # Apply the mask to k-space"
    ]
   },
   {
@@ -247,9 +247,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.2 64-bit ('fastmri': conda)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python38264bitfastmricondae6ff12e14a6d4c7fab7686eaa5d0b897"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -261,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7-final"
+   "version": "3.9.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some changes to `apply_mask` make it return 3 parameters, but the old tutorial only has two.