### PR TITLE
fixed apply mask

### DIFF
--- a/fastmri/data/transforms.py
+++ b/fastmri/data/transforms.py
@@ -76,8 +76,8 @@ def apply_mask(
     shape = (1,) * len(data.shape[:-3]) + tuple(data.shape[-3:])
     mask, num_low_frequencies = mask_func(shape, offset, seed)
     if padding is not None:
-        mask[:, :, : padding[0]] = 0
-        mask[:, :, padding[1] :] = 0  # padding value inclusive on right of zeros
+        mask[..., : padding[0], :] = 0
+        mask[..., padding[1] :, :] = 0  # padding value inclusive on right of zeros
 
     masked_data = data * mask + 0.0  # the + 0.0 removes the sign of the zeros
 


### PR DESCRIPTION
This fixes the apply mask function for the case of single-coil data.

Currently, when using the fastmri data module, the returned k-space are all 0, because during the padding fixing phase, all mask values are set to 0.

I can provide a minimal reproducible example if needed and create the corresponding issue.
This was such a minimal change that I didn't bother for now.