### PR TITLE
Fix for AnnotatedSliceDataset

### DIFF
--- a/fastmri/data/mri_data.py
+++ b/fastmri/data/mri_data.py
@@ -554,7 +554,7 @@ class AnnotatedSliceDataset(SliceDataset):
                 "height": -1,
                 "label": "",
             }
-        elif row.study_level == 'Yes':
+        elif row.study_level == "Yes":
             annotation = {
                 "fname": str(row.file),
                 "slice": "",

--- a/fastmri/data/mri_data.py
+++ b/fastmri/data/mri_data.py
@@ -554,6 +554,17 @@ class AnnotatedSliceDataset(SliceDataset):
                 "height": -1,
                 "label": "",
             }
+        elif row.study_level == 'Yes':
+            annotation = {
+                "fname": str(row.file),
+                "slice": "",
+                "study_level": "Yes",
+                "x": -1,
+                "y": -1,
+                "width": -1,
+                "height": -1,
+                "label": str(row.label),
+            }
         else:
             annotation = {
                 "fname": str(row.file),
@@ -569,7 +580,10 @@ class AnnotatedSliceDataset(SliceDataset):
 
     def download_csv(self, version, subsplit, path):
         # request file by git hash and mri type
-        url = f"https://raw.githubusercontent.com/microsoft/fastmri-plus/{version}/Annotations/{subsplit}.csv"
+        if version is None:
+            url = f"https://raw.githubusercontent.com/microsoft/fastmri-plus/main/Annotations/{subsplit}.csv"
+        else:
+            url = f"https://raw.githubusercontent.com/microsoft/fastmri-plus/{version}/Annotations/{subsplit}.csv"
         request = requests.get(url, timeout=10, stream=True)
 
         # create temporary folders


### PR DESCRIPTION
Fixes issue #275 

If no annotation_version is provided, the latest version of the annotation data will be used.

Also, some rows in the [annotation data](https://raw.githubusercontent.com/microsoft/fastmri-plus/main/Annotations/knee.csv) have study_level == 'Yes' and do not provide x- and y-values, which lead to an error previously. This is solved by setting the x- and y-value to -1 in this case, similar to the case when no annotation is provided for the MRI-volume.