### PR TITLE
typecast indices to long to avoid being interpreted as float

### DIFF
--- a/fastmri/models/varnet.py
+++ b/fastmri/models/varnet.py
@@ -198,7 +198,7 @@ class SensitivityModel(nn.Module):
 
         pad = (mask.shape[-2] - num_low_frequencies_tensor + 1) // 2
 
-        return pad, num_low_frequencies_tensor
+        return pad.type(torch.long), num_low_frequencies_tensor.type(torch.long)
 
     def forward(
         self,


### PR DESCRIPTION
in pytorch 2.0, the output of pad on line 199 is being interpreted as a float (even with the floor div). This raises an error when using the pad value for index computation. As a precaution, we cast to long which can be interpreted as an int