### PR TITLE
Updated slice indexing to correctly select the 20th slice

### DIFF
--- a/fastMRI_tutorial.ipynb
+++ b/fastMRI_tutorial.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "slice_kspace = volume_kspace[20] # Choosing the 20-th slice of this volume"
+    "slice_kspace = volume_kspace[:,19,:,:] # Choosing the 20-th slice of this volume"
    ]
   },
   {


### PR DESCRIPTION
Encountered an error when extracting slices from the fastMRI data. The indexing has now been corrected to receive the 20th slice without error.

- Indexing is zero-based.
- The slice is retrieved from the second position in the volume's dimensions.
