### PR TITLE
fix: replace np.product with np.prod

### DIFF
--- a/banding_removal/fastmri/data/test_transforms.py
+++ b/banding_removal/fastmri/data/test_transforms.py
@@ -17,7 +17,7 @@ from fastmri.data import transforms
 
 
 def create_input(shape):
-    input = np.arange(np.product(shape)).reshape(shape)
+    input = np.arange(np.prod(shape)).reshape(shape)
     input = torch.from_numpy(input).float()
     return input
 
@@ -179,7 +179,7 @@ def test_normalize_instance(shape):
     [3, 4, 5],
 ])
 def test_roll(shift, dim, shape):
-    input = np.arange(np.product(shape)).reshape(shape)
+    input = np.arange(np.prod(shape)).reshape(shape)
     out_torch = transforms.roll(torch.from_numpy(input), shift, dim).numpy()
     out_numpy = np.roll(input, shift, dim)
     assert np.allclose(out_torch, out_numpy)
@@ -190,7 +190,7 @@ def test_roll(shift, dim, shape):
     [2, 4, 6],
 ])
 def test_fftshift(shape):
-    input = np.arange(np.product(shape)).reshape(shape)
+    input = np.arange(np.prod(shape)).reshape(shape)
     out_torch = transforms.fftshift(torch.from_numpy(input)).numpy()
     out_numpy = np.fft.fftshift(input)
     assert np.allclose(out_torch, out_numpy)
@@ -202,7 +202,7 @@ def test_fftshift(shape):
     [2, 7, 5],
 ])
 def test_ifftshift(shape):
-    input = np.arange(np.product(shape)).reshape(shape)
+    input = np.arange(np.prod(shape)).reshape(shape)
     out_torch = transforms.ifftshift(torch.from_numpy(input)).numpy()
     out_numpy = np.fft.ifftshift(input)
     assert np.allclose(out_torch, out_numpy)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ SKIP_INTEGRATIONS = True
 
 
 def create_input(shape):
-    x = np.arange(np.product(shape)).reshape(shape)
+    x = np.arange(np.prod(shape)).reshape(shape)
     x = torch.from_numpy(x).float()
 
     return x

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -111,7 +111,7 @@ def test_root_sum_of_squares(shape, dim):
     ],
 )
 def test_roll(shift, dim, shape):
-    x = np.arange(np.product(shape)).reshape(shape)
+    x = np.arange(np.prod(shape)).reshape(shape)
     if isinstance(shift, int) and isinstance(dim, int):
         torch_shift = [shift]
         torch_dim = [dim]
@@ -132,7 +132,7 @@ def test_roll(shift, dim, shape):
     ],
 )
 def test_fftshift(shape):
-    x = np.arange(np.product(shape)).reshape(shape)
+    x = np.arange(np.prod(shape)).reshape(shape)
     out_torch = fastmri.fftshift(torch.from_numpy(x)).numpy()
     out_numpy = np.fft.fftshift(x)
 
@@ -148,7 +148,7 @@ def test_fftshift(shape):
     ],
 )
 def test_ifftshift(shape):
-    x = np.arange(np.product(shape)).reshape(shape)
+    x = np.arange(np.prod(shape)).reshape(shape)
     out_torch = fastmri.ifftshift(torch.from_numpy(x)).numpy()
     out_numpy = np.fft.ifftshift(x)
 


### PR DESCRIPTION
Using the old keyword raises errors when used with 2.x numpy versions. 